### PR TITLE
feat: Add Linux VM support using meda

### DIFF
--- a/src/lume/client.rs
+++ b/src/lume/client.rs
@@ -7,8 +7,8 @@ use crate::lume::errors::LumeError;
 use crate::lume::models::{CloneConfig, RunConfig, VmConfig, VmInfo};
 
 const DEFAULT_API_URL: &str = "http://127.0.0.1:3000/lume";
-const CONNECT_TIMEOUT: u64 = 6000;
-const MAX_TIMEOUT: u64 = 5000;
+const CONNECT_TIMEOUT: u64 = 10; // 10 seconds
+const MAX_TIMEOUT: u64 = 300; // 5 minutes
 
 pub struct LumeClient {
     client: Client,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
 mod lume;
+mod meda;
 mod vm_provision;
 
 use crate::lume::client::LumeClient;
-use crate::lume::setup::cleanup_log_files;
+use crate::lume::setup::cleanup_log_files as cleanup_lume_logs;
 use crate::lume::{
     check_template_exists, create_template, find_matching_template, generate_template_name,
 };
+use crate::meda::client::MedaClient;
+use crate::meda::setup::cleanup_log_files as cleanup_meda_logs;
 use crate::vm_provision::run_script_on_vm;
 use clap::Parser;
 use log::{debug, error, info, warn};
@@ -90,6 +93,7 @@ struct RunnerToProvision {
     os: String, // This is actually the image to use
     cpu: u32,
     memory: u32,
+    #[serde(default)]
     disk: u32,
     login: RunnerLogin,
 }
@@ -106,6 +110,11 @@ struct CommandResponse {
     output: String,
     error: String,
     agent: AgentInfo,
+}
+
+// Helper function to determine if we should use meda (Linux host) or lume (macOS host)
+fn use_meda() -> bool {
+    env::consts::OS == "linux"
 }
 
 // Helper function to determine OS from image name
@@ -224,53 +233,121 @@ impl CirunClient {
 
     async fn report_running_vms(&self) {
         info!("Reporting running VMs to API");
-        match LumeClient::new() {
-            Ok(lume) => {
-                match lume.list_vms().await {
-                    Ok(vms) => {
-                        let running_vms: Vec<_> =
-                            vms.into_iter().filter(|vm| vm.state == "running").collect();
-                        let url = format!("{}/agent", self.base_url);
 
-                        // Use the helper method instead of direct client access
-                        let res = self
-                            .create_request(reqwest::Method::POST, &url)
-                            .json(&json!({
-                                "agent": self.agent,
-                                "running_vms": running_vms.iter().map(|vm| {
-                                    json!({
-                                        "name": vm.name,
-                                        "os": vm.os,
-                                        "cpu": vm.cpu,
-                                        "memory": vm.memory,
-                                        "disk_size": vm.disk_size.total
-                                    })
-                                }).collect::<Vec<_>>()
-                            }))
-                            .send()
-                            .await;
+        if use_meda() {
+            // Use meda for Linux
+            match MedaClient::new() {
+                Ok(meda) => {
+                    match meda.list_vms().await {
+                        Ok(vms) => {
+                            let running_vms: Vec<_> =
+                                vms.into_iter().filter(|vm| vm.state == "running").collect();
+                            let url = format!("{}/agent", self.base_url);
 
-                        match res {
-                            Ok(response) => {
-                                let status = response.status();
-                                info!("API response status: {}", status);
-                                if let Some(req_id) = response.headers().get("X-Request-ID") {
-                                    if let Ok(id) = req_id.to_str() {
-                                        info!("Response received with request ID: {}", id);
+                            let res = self
+                                .create_request(reqwest::Method::POST, &url)
+                                .json(&json!({
+                                    "agent": self.agent,
+                                    "running_vms": running_vms.iter().map(|vm| {
+                                        json!({
+                                            "name": vm.name,
+                                            "os": "linux",
+                                            "cpu": vm.cpus.unwrap_or(2),
+                                            "memory": vm.memory.as_ref().and_then(|m| m.trim_end_matches("GB").trim_end_matches("G").parse::<u64>().ok()).unwrap_or(2048),
+                                            "disk_size": 0  // Meda doesn't report disk size in list
+                                        })
+                                    }).collect::<Vec<_>>()
+                                }))
+                                .send()
+                                .await;
+
+                            match res {
+                                Ok(response) => {
+                                    let status = response.status();
+                                    info!("API response status: {}", status);
+                                    if let Some(req_id) = response.headers().get("X-Request-ID") {
+                                        if let Ok(id) = req_id.to_str() {
+                                            info!("Response received with request ID: {}", id);
+                                        }
                                     }
                                 }
+                                Err(e) => error!("Failed to send running VMs: {}", e),
                             }
-                            Err(e) => error!("Failed to send running VMs: {}", e),
                         }
+                        Err(e) => error!("Failed to list VMs: {:?}", e),
                     }
-                    Err(e) => error!("Failed to list VMs: {:?}", e),
                 }
+                Err(e) => error!("Failed to initialize Meda client: {:?}", e),
             }
-            Err(e) => error!("Failed to initialize Lume client: {:?}", e),
+        } else {
+            // Use lume for macOS
+            match LumeClient::new() {
+                Ok(lume) => {
+                    match lume.list_vms().await {
+                        Ok(vms) => {
+                            let running_vms: Vec<_> =
+                                vms.into_iter().filter(|vm| vm.state == "running").collect();
+                            let url = format!("{}/agent", self.base_url);
+
+                            // Use the helper method instead of direct client access
+                            let res = self
+                                .create_request(reqwest::Method::POST, &url)
+                                .json(&json!({
+                                    "agent": self.agent,
+                                    "running_vms": running_vms.iter().map(|vm| {
+                                        json!({
+                                            "name": vm.name,
+                                            "os": vm.os,
+                                            "cpu": vm.cpu,
+                                            "memory": vm.memory,
+                                            "disk_size": vm.disk_size.total
+                                        })
+                                    }).collect::<Vec<_>>()
+                                }))
+                                .send()
+                                .await;
+
+                            match res {
+                                Ok(response) => {
+                                    let status = response.status();
+                                    info!("API response status: {}", status);
+                                    if let Some(req_id) = response.headers().get("X-Request-ID") {
+                                        if let Ok(id) = req_id.to_str() {
+                                            info!("Response received with request ID: {}", id);
+                                        }
+                                    }
+                                }
+                                Err(e) => error!("Failed to send running VMs: {}", e),
+                            }
+                        }
+                        Err(e) => error!("Failed to list VMs: {:?}", e),
+                    }
+                }
+                Err(e) => error!("Failed to initialize Lume client: {:?}", e),
+            }
         }
     }
 
     async fn provision_runner(
+        &self,
+        runner_name: &str,
+        provision_script: &str,
+        template_name: &str,
+        runner_login: &RunnerLogin,
+        cpu: u32,
+        memory: u32,
+        disk: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if use_meda() {
+            self.provision_runner_meda(runner_name, provision_script, template_name, runner_login, cpu, memory, disk)
+                .await
+        } else {
+            self.provision_runner_lume(runner_name, provision_script, template_name, runner_login)
+                .await
+        }
+    }
+
+    async fn provision_runner_lume(
         &self,
         runner_name: &str,
         provision_script: &str,
@@ -375,43 +452,188 @@ impl CirunClient {
         }
     }
 
-    async fn delete_runner(&self, runner_name: &str) -> Result<(), Box<dyn std::error::Error>> {
-        match LumeClient::new() {
-            Ok(lume) => {
-                info!("Attempting to delete runner VM: {}", runner_name);
+    async fn provision_runner_meda(
+        &self,
+        runner_name: &str,
+        provision_script: &str,
+        image: &str,
+        runner_login: &RunnerLogin,
+        cpu: u32,
+        memory: u32,
+        disk: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use crate::meda::models::VmRunRequest;
 
-                // Check if VM exists by trying to get its details
-                match lume.get_vm(runner_name).await {
-                    Ok(vm) => {
-                        info!("Found VM '{}' with status: {}", runner_name, vm.state);
+        match MedaClient::new() {
+            Ok(meda) => {
+                // Check if VM already exists
+                match meda.get_vm(runner_name).await {
+                    Ok(vm_info) => {
+                        if vm_info.state == "running" {
+                            info!(
+                                "VM '{}' already exists and is running. Skipping creation.",
+                                runner_name
+                            );
+                            // Still try to run provisioning script
+                        } else {
+                            info!("VM '{}' exists but is not running. Starting it...", runner_name);
+                            meda.start_vm(runner_name).await?;
+                        }
+                    }
+                    Err(_) => {
+                        // VM doesn't exist, create and run it from image
+                        info!(
+                            "VM '{}' does not exist. Creating from image '{}'...",
+                            runner_name, image
+                        );
 
-                        // Delete the VM
-                        match lume.delete_vm(runner_name).await {
+                        // For meda, we use the image name directly (template_name parameter contains the image)
+                        let run_request = VmRunRequest {
+                            image: image.to_string(),
+                            name: Some(runner_name.to_string()),
+                            memory: Some(format!("{}G", memory)),
+                            cpus: Some(cpu),
+                            disk_size: Some(format!("{}G", disk)),
+                        };
+
+                        match meda.run_vm(run_request).await {
                             Ok(_) => {
-                                info!("VM '{}' deleted successfully", runner_name);
-                                Ok(())
+                                info!("VM '{}' created and started successfully", runner_name);
                             }
                             Err(e) => {
-                                error!("Failed to delete VM '{}': {:?}", runner_name, e);
-                                Err(format!("Failed to delete VM '{}': {:?}", runner_name, e)
-                                    .into())
+                                error!("Failed to create and run VM '{}': {:?}", runner_name, e);
+                                return Err(format!(
+                                    "Failed to create and run VM from image '{}': {:?}",
+                                    image, e
+                                )
+                                .into());
                             }
                         }
                     }
+                }
+
+                // Wait for VM to get an IP address
+                info!("Waiting for VM '{}' to get an IP address...", runner_name);
+                let ip_address = match meda.wait_for_vm_ip(runner_name, 300).await {
+                    Ok(ip) => ip,
                     Err(e) => {
-                        warn!(
-                            "VM '{}' not found or error retrieving VM details: {:?}",
-                            runner_name, e
-                        );
-                        // Consider this a success since the VM doesn't exist anyway
-                        info!("VM '{}' doesn't exist or can't be accessed - considering delete successful", runner_name);
+                        error!("Failed to get VM IP address: {:?}", e);
+                        return Err(e.into());
+                    }
+                };
+
+                info!("VM '{}' has IP address: {}", runner_name, ip_address);
+
+                // Read SSH credentials
+                let username = runner_login.username.clone();
+                let password = runner_login.password.clone();
+
+                info!("Provisioning runner: {}", runner_name);
+                info!("Running provision script on VM");
+
+                // For meda, we need to use a simplified approach since we don't have the lume client
+                // We'll use run_script_on_vm but we need to adapt it for meda
+                match run_script_on_vm_meda(
+                    &meda,
+                    runner_name,
+                    &ip_address,
+                    provision_script,
+                    &username,
+                    &password,
+                    20,
+                    true,
+                )
+                .await
+                {
+                    Ok(output) => {
+                        info!("Runner provisioning completed successfully");
+                        info!("Script output: {}", output);
                         Ok(())
+                    }
+                    Err(e) => {
+                        error!("Failed to provision runner: {}", e);
+                        Err(e)
                     }
                 }
             }
             Err(e) => {
-                error!("Failed to initialize Lume client: {:?}", e);
+                error!("Failed to initialize Meda client: {:?}", e);
                 Err(e.into())
+            }
+        }
+    }
+
+    async fn delete_runner(&self, runner_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+        if use_meda() {
+            match MedaClient::new() {
+                Ok(meda) => {
+                    info!("Attempting to delete runner VM: {}", runner_name);
+                    match meda.get_vm(runner_name).await {
+                        Ok(_) => {
+                            match meda.delete_vm(runner_name).await {
+                                Ok(_) => {
+                                    info!("Successfully deleted runner VM: {}", runner_name);
+                                    Ok(())
+                                }
+                                Err(e) => {
+                                    error!("Failed to delete runner VM {}: {:?}", runner_name, e);
+                                    Err(format!("Failed to delete VM: {:?}", e).into())
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "VM '{}' not found or error retrieving VM details: {:?}",
+                                runner_name, e
+                            );
+                            info!("VM '{}' doesn't exist or can't be accessed - considering delete successful", runner_name);
+                            Ok(())
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to initialize Meda client: {:?}", e);
+                    Err(e.into())
+                }
+            }
+        } else {
+            match LumeClient::new() {
+                Ok(lume) => {
+                    info!("Attempting to delete runner VM: {}", runner_name);
+
+                    // Check if VM exists by trying to get its details
+                    match lume.get_vm(runner_name).await {
+                        Ok(vm) => {
+                            info!("Found VM '{}' with status: {}", runner_name, vm.state);
+
+                            // Delete the VM
+                            match lume.delete_vm(runner_name).await {
+                                Ok(_) => {
+                                    info!("VM '{}' deleted successfully", runner_name);
+                                    Ok(())
+                                }
+                                Err(e) => {
+                                    error!("Failed to delete VM '{}': {:?}", runner_name, e);
+                                    Err(format!("Failed to delete VM '{}': {:?}", runner_name, e)
+                                        .into())
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                "VM '{}' not found or error retrieving VM details: {:?}",
+                                runner_name, e
+                            );
+                            // Consider this a success since the VM doesn't exist anyway
+                            info!("VM '{}' doesn't exist or can't be accessed - considering delete successful", runner_name);
+                            Ok(())
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to initialize Lume client: {:?}", e);
+                    Err(e.into())
+                }
             }
         }
     }
@@ -479,42 +701,48 @@ impl CirunClient {
                     os: get_os_from_image(&runner.os), // Determine OS type from image name
                 };
 
-                // First, try to find an existing template with matching configuration
-                let template_name = if let Some(existing_template) =
-                    find_matching_template(&template_config).await
-                {
-                    info!(
-                        "Found existing template with matching configuration: {}",
-                        existing_template
-                    );
-                    existing_template
+                // For meda (Linux), use the image name directly. Templates are only for lume (macOS).
+                let template_name = if use_meda() {
+                    info!("Using meda on Linux - using image name directly: {}", runner.os);
+                    runner.os.clone()
                 } else {
-                    // Generate a new template name
-                    let generated_name = generate_template_name(&template_config);
-
-                    // Check if the template with this specific name already exists
-                    let template_exists = check_template_exists(&generated_name).await;
-
-                    if !template_exists {
-                        // Create the template if it doesn't exist
-                        info!("No matching template found. Creating new template '{}' from image '{}'",
-                             generated_name, template_config.image);
-
-                        match create_template(&template_config, &generated_name).await {
-                            Ok(_) => {
-                                info!("✅ Successfully created template: {}", generated_name);
-                                generated_name
-                            }
-                            Err(e) => {
-                                error!("❌ Failed to create template {}: {}", generated_name, e);
-                                // If template creation fails, fall back to default template
-                                info!("Falling back to default template due to template creation failure");
-                                "cirun-runner-template".to_string()
-                            }
-                        }
+                    // For lume (macOS), try to find an existing template with matching configuration
+                    if let Some(existing_template) =
+                        find_matching_template(&template_config).await
+                    {
+                        info!(
+                            "Found existing template with matching configuration: {}",
+                            existing_template
+                        );
+                        existing_template
                     } else {
-                        info!("Using existing template: {}", generated_name);
-                        generated_name
+                        // Generate a new template name
+                        let generated_name = generate_template_name(&template_config);
+
+                        // Check if the template with this specific name already exists
+                        let template_exists = check_template_exists(&generated_name).await;
+
+                        if !template_exists {
+                            // Create the template if it doesn't exist
+                            info!("No matching template found. Creating new template '{}' from image '{}'",
+                                 generated_name, template_config.image);
+
+                            match create_template(&template_config, &generated_name).await {
+                                Ok(_) => {
+                                    info!("✅ Successfully created template: {}", generated_name);
+                                    generated_name
+                                }
+                                Err(e) => {
+                                    error!("❌ Failed to create template {}: {}", generated_name, e);
+                                    // If template creation fails, fall back to default template
+                                    info!("Falling back to default template due to template creation failure");
+                                    "cirun-runner-template".to_string()
+                                }
+                            }
+                        } else {
+                            info!("Using existing template: {}", generated_name);
+                            generated_name
+                        }
                     }
                 };
 
@@ -530,6 +758,9 @@ impl CirunClient {
                         &runner.provision_script,
                         &template_name,
                         &runner.login,
+                        runner.cpu,
+                        runner.memory,
+                        runner.disk,
                     )
                     .await
                 {
@@ -558,6 +789,9 @@ impl CirunClient {
                                     &runner.provision_script,
                                     "cirun-runner-template",
                                     &runner.login,
+                                    runner.cpu,
+                                    runner.memory,
+                                    runner.disk,
                                 )
                                 .await
                             {
@@ -580,6 +814,174 @@ impl CirunClient {
 
         Ok(json)
     }
+}
+
+// Helper function for running scripts on VMs using meda (simpler version without lume client)
+async fn run_script_on_vm_meda(
+    _meda: &MedaClient,
+    vm_name: &str,
+    ip_address: &str,
+    script_content: &str,
+    username: &str,
+    password: &str,
+    _timeout_seconds: u64,
+    run_detached: bool,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use std::fs::{remove_file, File};
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+    use std::time::Instant;
+    use tempfile::NamedTempFile;
+
+    info!("VM '{}' is ready with IP: {}", vm_name, ip_address);
+
+    // Step 1: Create a temporary file for the script
+    info!("Creating temporary script file");
+    let mut temp_file = NamedTempFile::new()?;
+    temp_file.write_all(script_content.as_bytes())?;
+    let temp_file_path = temp_file
+        .path()
+        .to_str()
+        .ok_or("Failed to get temporary file path")?;
+
+    // Step 2: Create a temporary password file for sshpass
+    let temp_dir = std::env::temp_dir();
+    let password_file_path = temp_dir.join(format!(
+        "sshpass_{}.txt",
+        Instant::now().elapsed().as_millis()
+    ));
+
+    let mut file = File::create(&password_file_path)?;
+    file.write_all(password.as_bytes())?;
+
+    // Restrict permissions on the password file
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let metadata = file.metadata()?;
+        let mut permissions = metadata.permissions();
+        permissions.set_mode(0o600);
+        std::fs::set_permissions(&password_file_path, permissions)?;
+    }
+
+    let password_file_str = password_file_path.to_string_lossy().to_string();
+    info!("Created temporary password file for SSH authentication");
+
+    // Step 3: Setup SSH options
+    let ssh_options = vec![
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "ConnectTimeout=10",
+    ];
+
+    // Step 4: Test SSH connection with retries (SSH may not be ready immediately after VM boot)
+    info!("Waiting for SSH to be ready on VM (max 60 seconds)...");
+    let max_ssh_retries = 12; // 12 retries * 5 seconds = 60 seconds max
+    let mut ssh_ready = false;
+
+    for attempt in 1..=max_ssh_retries {
+        let output = Command::new("sshpass")
+            .arg("-f")
+            .arg(&password_file_str)
+            .arg("ssh")
+            .args(&ssh_options)
+            .arg(format!("{}@{}", username, ip_address))
+            .arg("echo 'SSH connection test successful'")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()?;
+
+        if output.status.success() {
+            info!("✔ SSH connection successful (attempt {}/{})", attempt, max_ssh_retries);
+            ssh_ready = true;
+            break;
+        } else {
+            let error_msg = String::from_utf8_lossy(&output.stderr);
+            info!("SSH not ready yet (attempt {}/{}): {}", attempt, max_ssh_retries, error_msg.trim());
+            if attempt < max_ssh_retries {
+                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+            }
+        }
+    }
+
+    if !ssh_ready {
+        remove_file(&password_file_path).ok();
+        return Err("SSH connection failed after multiple retries - VM may not be fully booted".into());
+    }
+
+    // Step 5: Copy the script to the VM
+    let remote_script_path = format!("/tmp/script_{}.sh", Instant::now().elapsed().as_secs());
+    info!("Copying script to VM at {}", remote_script_path);
+
+    let output = Command::new("sshpass")
+        .arg("-f")
+        .arg(&password_file_str)
+        .arg("scp")
+        .args(&ssh_options)
+        .arg(temp_file_path)
+        .arg(format!(
+            "{}@{}:{}",
+            username, ip_address, remote_script_path
+        ))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    if !output.status.success() {
+        let error_msg = String::from_utf8_lossy(&output.stderr);
+        remove_file(&password_file_path).ok();
+        return Err(format!("SCP failed: {}", error_msg).into());
+    }
+
+    info!("✔ SCP transfer successful");
+
+    // Step 6: Execute the script on the VM with sudo (provision scripts need root privileges)
+    let output = if run_detached {
+        info!("Executing script on VM in detached mode with sudo");
+        Command::new("sshpass")
+            .arg("-f")
+            .arg(&password_file_str)
+            .arg("ssh")
+            .args(&ssh_options)
+            .arg(format!("{}@{}", username, ip_address))
+            .arg(format!(
+                "chmod +x {} && sudo nohup bash {} > /tmp/script_stdout.log 2> /tmp/script_stderr.log & echo $!",
+                remote_script_path, remote_script_path
+            ))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()?
+    } else {
+        info!("Executing script on VM and waiting for completion with sudo");
+        Command::new("sshpass")
+            .arg("-f")
+            .arg(&password_file_str)
+            .arg("ssh")
+            .args(&ssh_options)
+            .arg(format!("{}@{}", username, ip_address))
+            .arg(format!(
+                "chmod +x {} && sudo bash {}",
+                remote_script_path, remote_script_path
+            ))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()?
+    };
+
+    // Step 7: Clean up password file
+    remove_file(&password_file_path).ok();
+
+    if !output.status.success() {
+        let error_msg = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Script execution failed: {}", error_msg).into());
+    }
+
+    let script_output = String::from_utf8_lossy(&output.stdout).to_string();
+    info!("Script execution completed successfully.");
+    Ok(script_output)
 }
 
 #[tokio::main]
@@ -607,34 +1009,67 @@ async fn main() {
     info!("Cirun API URL: {}", cirun_api_url);
     let client = CirunClient::new(&cirun_api_url, &args.api_token, agent_info);
 
-    // Check Lume connectivity before entering the main loop
-    lume::download_and_run_lume().await;
-    info!("Checking Lume connectivity...");
-    match LumeClient::new() {
-        Ok(lume) => match lume.list_vms().await {
-            Ok(vms) => {
-                info!("✅ Successfully connected to Lume. Found {} VMs", vms.len());
-                for vm in vms {
-                    info!(
-                        "- {} ({}, {}, CPU: {}, Memory: {}, Disk: {})",
-                        vm.name, vm.state, vm.os, vm.cpu, vm.memory, vm.disk_size.total
-                    );
+    // Set up log cleanup parameters based on platform
+    let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let log_dir: PathBuf;
+
+    // Download and run the appropriate VM manager based on platform
+    if use_meda() {
+        info!("Detected Linux platform - using Meda for VM management");
+        meda::download_and_run_meda().await;
+        log_dir = PathBuf::from(&home_dir).join(".meda/logs");
+
+        info!("Checking Meda connectivity...");
+        match MedaClient::new() {
+            Ok(meda) => match meda.list_vms().await {
+                Ok(vms) => {
+                    info!("✅ Successfully connected to Meda. Found {} VMs", vms.len());
+                    for vm in vms {
+                        info!(
+                            "- {} ({})",
+                            vm.name, vm.state
+                        );
+                    }
                 }
-            }
+                Err(e) => {
+                    error!("❌ Failed to connect to Meda API: {:?}", e);
+                    error!("Agent will continue but VM operations will likely fail");
+                }
+            },
             Err(e) => {
-                error!("❌ Failed to connect to Lume API: {:?}", e);
+                error!("❌ Failed to initialize Meda client: {:?}", e);
                 error!("Agent will continue but VM operations will likely fail");
             }
-        },
-        Err(e) => {
-            error!("❌ Failed to initialize Lume client: {:?}", e);
-            error!("Agent will continue but VM operations will likely fail");
+        }
+    } else {
+        info!("Detected macOS platform - using Lume for VM management");
+        lume::download_and_run_lume().await;
+        log_dir = PathBuf::from(&home_dir).join(".lume/logs");
+
+        info!("Checking Lume connectivity...");
+        match LumeClient::new() {
+            Ok(lume) => match lume.list_vms().await {
+                Ok(vms) => {
+                    info!("✅ Successfully connected to Lume. Found {} VMs", vms.len());
+                    for vm in vms {
+                        info!(
+                            "- {} ({}, {}, CPU: {}, Memory: {}, Disk: {})",
+                            vm.name, vm.state, vm.os, vm.cpu, vm.memory, vm.disk_size.total
+                        );
+                    }
+                }
+                Err(e) => {
+                    error!("❌ Failed to connect to Lume API: {:?}", e);
+                    error!("Agent will continue but VM operations will likely fail");
+                }
+            },
+            Err(e) => {
+                error!("❌ Failed to initialize Lume client: {:?}", e);
+                error!("Agent will continue but VM operations will likely fail");
+            }
         }
     }
 
-    // Set up log cleanup parameters
-    let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    let log_dir = PathBuf::from(&home_dir).join(".lume/logs");
     let mut last_cleanup = SystemTime::now();
     let cleanup_interval = Duration::from_secs(24 * 60 * 60); // Daily log cleanup
 
@@ -660,7 +1095,13 @@ async fn main() {
         // Check if it's time to clean up logs
         if let Ok(duration) = SystemTime::now().duration_since(last_cleanup) {
             if duration >= cleanup_interval {
-                match cleanup_log_files(&log_dir, 7, 100) {
+                let cleanup_result = if use_meda() {
+                    cleanup_meda_logs(&log_dir, 7, 100)
+                } else {
+                    cleanup_lume_logs(&log_dir, 7, 100)
+                };
+
+                match cleanup_result {
                     // Keep logs for 7 days, rotate at 100MB
                     Ok(_) => {
                         last_cleanup = SystemTime::now();

--- a/src/meda/client.rs
+++ b/src/meda/client.rs
@@ -1,0 +1,304 @@
+use backon::{ExponentialBuilder, Retryable};
+use log::{info, warn};
+use reqwest::Client;
+use std::time::Duration;
+
+use crate::meda::errors::MedaError;
+use crate::meda::models::{VmCreateRequest, VmDetailResponse, VmInfo, VmListResponse, VmRunRequest};
+
+const DEFAULT_API_URL: &str = "http://127.0.0.1:7777/api/v1";
+const CONNECT_TIMEOUT: u64 = 6000;
+const MAX_TIMEOUT: u64 = 5000;
+
+pub struct MedaClient {
+    client: Client,
+    base_url: String,
+}
+
+impl MedaClient {
+    pub fn new() -> Result<Self, MedaError> {
+        Self::with_base_url(DEFAULT_API_URL)
+    }
+
+    pub fn get_base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn with_base_url(base_url: &str) -> Result<Self, MedaError> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(MAX_TIMEOUT))
+            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT))
+            .pool_idle_timeout(Duration::from_secs(90))
+            .pool_max_idle_per_host(10)
+            .tcp_keepalive(Duration::from_secs(60))
+            .build()
+            .map_err(MedaError::from)?;
+
+        Ok(Self {
+            client,
+            base_url: base_url.to_string(),
+        })
+    }
+
+    /// Create a new VM
+    pub async fn create_vm(&self, config: VmCreateRequest) -> Result<(), MedaError> {
+        let url = format!("{}/vms", self.base_url);
+
+        let response = self.client.post(&url).json(&config).send().await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(MedaError::ApiError(format!(
+                "Failed to create VM: {}",
+                error_text
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Run a VM from an image (equivalent to "meda run")
+    /// This creates and starts the VM in one operation
+    pub async fn run_vm(&self, config: VmRunRequest) -> Result<(), MedaError> {
+        let url = format!("{}/images/run", self.base_url);
+
+        info!("Running VM from image: {}", config.image);
+
+        let response = self.client.post(&url).json(&config).send().await?;
+        let status = response.status();
+        let response_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Failed to read response body".to_string());
+
+        info!(
+            "VM Run API Response: Status = {}, Body = {}",
+            status, response_text
+        );
+
+        if !status.is_success() {
+            return Err(MedaError::ApiError(format!(
+                "Failed to run VM: {}",
+                response_text
+            )));
+        }
+
+        info!("Successfully started VM from image: {}", config.image);
+        Ok(())
+    }
+
+    /// Start an existing VM
+    pub async fn start_vm(&self, name: &str) -> Result<(), MedaError> {
+        let url = format!("{}/vms/{}/start", self.base_url, name);
+
+        info!("Starting VM: {}", name);
+
+        let response = self.client.post(&url).send().await?;
+        let status = response.status();
+        let response_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Failed to read response body".to_string());
+
+        info!(
+            "VM Start API Response: Status = {}, Body = {}",
+            status, response_text
+        );
+
+        if !status.is_success() {
+            return Err(MedaError::ApiError(format!(
+                "Failed to start VM: {}",
+                response_text
+            )));
+        }
+
+        info!("Successfully started VM: {}", name);
+        Ok(())
+    }
+
+    /// Stop a running VM
+    pub async fn stop_vm(&self, name: &str) -> Result<(), MedaError> {
+        let url = format!("{}/vms/{}/stop", self.base_url, name);
+
+        info!("Stopping VM: {}", name);
+
+        let response = self.client.post(&url).send().await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(MedaError::ApiError(format!(
+                "Failed to stop VM: {}",
+                error_text
+            )));
+        }
+
+        info!("Successfully stopped VM: {}", name);
+        Ok(())
+    }
+
+    /// Delete a VM
+    pub async fn delete_vm(&self, name: &str) -> Result<(), MedaError> {
+        let url = format!("{}/vms/{}", self.base_url, name);
+
+        info!("Deleting VM {}", name);
+
+        let send_delete_request = || async {
+            let response = self
+                .client
+                .delete(&url)
+                .send()
+                .await
+                .map_err(|e| MedaError::ApiError(format!("HTTP request failed: {:?}", e)))?;
+
+            let status = response.status();
+            let response_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+
+            info!("Delete operation response status: {}", status);
+            info!("Delete operation response body: {}", response_text);
+
+            if !status.is_success() {
+                return Err(MedaError::ApiError(format!(
+                    "Failed to delete VM: {}",
+                    response_text
+                )));
+            }
+            Ok(())
+        };
+
+        // Retry logic with proper error conversion
+        send_delete_request
+            .retry(ExponentialBuilder::default().with_max_times(5))
+            .sleep(tokio::time::sleep)
+            .when(|e| matches!(e, MedaError::ApiError(_)))
+            .notify(|err, dur| warn!("Retrying VM deletion after {:?}: {:?}", dur, err))
+            .await
+            .map_err(|e| MedaError::ApiError(format!("Retry exhausted: {:?}", e)))?;
+
+        info!("VM {} successfully deleted", name);
+        Ok(())
+    }
+
+    /// List all VMs
+    pub async fn list_vms(&self) -> Result<Vec<VmInfo>, MedaError> {
+        let url = format!("{}/vms", self.base_url);
+
+        let response = self.client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(MedaError::ApiError(format!(
+                "Failed to list VMs: {}",
+                error_text
+            )));
+        }
+
+        let vm_list = response.json::<VmListResponse>().await?;
+        Ok(vm_list.vms)
+    }
+
+    /// Get details of a specific VM
+    pub async fn get_vm(&self, name: &str) -> Result<VmDetailResponse, MedaError> {
+        info!("Getting VM details for {}", name);
+        let url = format!("{}/vms/{}", self.base_url, name);
+
+        let max_retries = 3;
+        let mut attempts = 0;
+        let retry_delay = Duration::from_millis(300);
+
+        loop {
+            attempts += 1;
+            match self.client.get(&url).send().await {
+                Ok(response) => {
+                    if response.status().is_success() {
+                        match response.json::<VmDetailResponse>().await {
+                            Ok(vm_info) => return Ok(vm_info),
+                            Err(e) => {
+                                warn!(
+                                    "Failed to parse VM details JSON (attempt {}/{}): {:?}",
+                                    attempts, max_retries, e
+                                );
+                                if attempts >= max_retries {
+                                    return Err(MedaError::RequestError(e));
+                                }
+                            }
+                        }
+                    } else {
+                        let error_text = response
+                            .text()
+                            .await
+                            .unwrap_or_else(|_| "Unknown error".to_string());
+                        if attempts >= max_retries {
+                            return Err(MedaError::ApiError(format!(
+                                "Failed to get VM details: {}",
+                                error_text
+                            )));
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to get VM details (attempt {}/{}): {:?}",
+                        attempts, max_retries, e
+                    );
+                    if attempts >= max_retries {
+                        return Err(MedaError::RequestError(e));
+                    }
+                }
+            }
+
+            tokio::time::sleep(retry_delay).await;
+        }
+    }
+
+    /// Wait for a VM to have an IP address
+    pub async fn wait_for_vm_ip(
+        &self,
+        vm_name: &str,
+        timeout_seconds: u64,
+    ) -> Result<String, MedaError> {
+        let start = std::time::Instant::now();
+        let timeout = Duration::from_secs(timeout_seconds);
+
+        info!(
+            "Waiting for VM {} to get an IP address (timeout: {}s)...",
+            vm_name, timeout_seconds
+        );
+
+        loop {
+            if start.elapsed() > timeout {
+                return Err(MedaError::ApiError(format!(
+                    "Timeout waiting for VM {} to get an IP address",
+                    vm_name
+                )));
+            }
+
+            match self.get_vm(vm_name).await {
+                Ok(vm_info) => {
+                    if let Some(ip) = vm_info.ip {
+                        if !ip.is_empty() {
+                            info!("VM {} has IP address: {}", vm_name, ip);
+                            return Ok(ip);
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Error getting VM info: {:?}", e);
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+}

--- a/src/meda/errors.rs
+++ b/src/meda/errors.rs
@@ -1,0 +1,33 @@
+use reqwest::Error as ReqwestError;
+use serde::de::StdError;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum MedaError {
+    RequestError(ReqwestError),
+    ApiError(String),
+}
+
+impl fmt::Display for MedaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MedaError::RequestError(err) => write!(f, "Request error: {}", err),
+            MedaError::ApiError(msg) => write!(f, "API error: {}", msg),
+        }
+    }
+}
+
+impl StdError for MedaError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            MedaError::RequestError(err) => Some(err),
+            MedaError::ApiError(_) => None,
+        }
+    }
+}
+
+impl From<ReqwestError> for MedaError {
+    fn from(error: ReqwestError) -> Self {
+        MedaError::RequestError(error)
+    }
+}

--- a/src/meda/mod.rs
+++ b/src/meda/mod.rs
@@ -1,0 +1,10 @@
+// Re-export all public items from submodules
+pub mod client;
+pub mod errors;
+pub mod models;
+pub mod setup;
+
+// Re-export the main types for easier access
+pub use self::client::MedaClient;
+pub use self::models::*;
+pub use self::setup::*;

--- a/src/meda/mod.rs
+++ b/src/meda/mod.rs
@@ -3,8 +3,3 @@ pub mod client;
 pub mod errors;
 pub mod models;
 pub mod setup;
-
-// Re-export the main types for easier access
-pub use self::client::MedaClient;
-pub use self::models::*;
-pub use self::setup::*;

--- a/src/meda/models.rs
+++ b/src/meda/models.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct VmCreateRequest {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/meda/models.rs
+++ b/src/meda/models.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VmCreateRequest {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpus: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "disk")]
+    pub disk_size: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VmRunRequest {
+    pub image: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpus: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "disk")]
+    pub disk_size: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VmInfo {
+    pub name: String,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpus: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VmListResponse {
+    pub vms: Vec<VmInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VmDetailResponse {
+    pub name: String,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpus: Option<u32>,
+}

--- a/src/meda/setup.rs
+++ b/src/meda/setup.rs
@@ -1,0 +1,302 @@
+use log::{error, info, warn};
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::{thread, time::Duration, time::SystemTime};
+
+use chrono::{DateTime, Utc};
+use std::path::Path;
+
+pub async fn download_and_run_meda() {
+    // Spawn a blocking task to handle the file operations
+    let result = tokio::task::spawn_blocking(download_and_run_meda_internal).await;
+
+    // Handle the result
+    match result {
+        Ok(Ok(_)) => info!("Meda setup complete"),
+        Ok(Err(e)) => error!("Meda setup failed: {}", e),
+        Err(e) => error!("Task error: {}", e),
+    }
+}
+
+// Function to clean up old log files
+pub fn cleanup_log_files(
+    log_dir: &Path,
+    max_age_days: u64,
+    max_size_mb: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Checking log files for cleanup...");
+
+    if !log_dir.exists() {
+        return Ok(());
+    }
+
+    let max_age = Duration::from_secs(max_age_days * 24 * 60 * 60);
+    let max_size = max_size_mb * 1024 * 1024; // Convert MB to bytes
+    let now = SystemTime::now();
+
+    let entries = fs::read_dir(log_dir)?;
+
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+
+        // Skip if not a file or doesn't have .log extension
+        if !path.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("log") {
+            continue;
+        }
+
+        let metadata = fs::metadata(&path)?;
+        let file_size = metadata.len();
+
+        // Check file age
+        if let Ok(modified) = metadata.modified() {
+            if let Ok(age) = now.duration_since(modified) {
+                if age > max_age {
+                    info!(
+                        "Removing old log file: {:?} (age: {} days)",
+                        path,
+                        age.as_secs() / (24 * 60 * 60)
+                    );
+                    fs::remove_file(&path)?;
+                    continue;
+                }
+            }
+        }
+
+        // Check file size
+        if file_size > max_size {
+            info!(
+                "Log file too large, rotating: {:?} (size: {:.2} MB)",
+                path,
+                file_size as f64 / 1024.0 / 1024.0
+            );
+
+            // Create a backup with timestamp
+            let timestamp: DateTime<Utc> = metadata
+                .modified()
+                .unwrap_or_else(|_| SystemTime::now())
+                .into();
+
+            let backup_path =
+                path.with_extension(format!("log.{}", timestamp.format("%Y%m%d%H%M%S")));
+
+            // Rename the current log file to the backup name
+            fs::rename(&path, &backup_path)?;
+
+            // Create a new empty log file
+            fs::File::create(&path)?;
+
+            // Limit the number of backup files (keep the 5 most recent)
+            let mut backups: Vec<_> = fs::read_dir(log_dir)?
+                .filter_map(Result::ok)
+                .filter(|e| {
+                    let p = e.path();
+                    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    name.starts_with(&path.file_name().unwrap().to_str().unwrap().to_string())
+                        && name.contains("log.")
+                })
+                .collect();
+
+            backups.sort_by_key(|e| std::cmp::Reverse(e.path()));
+
+            // Remove older backups (keep 5 newest)
+            for old_backup in backups.into_iter().skip(5) {
+                let old_path = old_backup.path();
+                info!("Removing old backup log: {:?}", old_path);
+                let _ = fs::remove_file(old_path);
+            }
+        }
+    }
+
+    info!("Log cleanup complete");
+    Ok(())
+}
+
+fn download_and_run_meda_internal() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let install_dir = PathBuf::from(format!("{}/.meda", std::env::var("HOME")?));
+    let meda_bin_path = install_dir.join("meda");
+
+    // Create installation directory if it doesn't exist
+    if !install_dir.exists() {
+        fs::create_dir_all(&install_dir)?;
+        info!("Created directory: {:?}", install_dir);
+    }
+
+    // Check if meda is already installed in common locations
+    let possible_paths = vec![
+        meda_bin_path.clone(),
+        PathBuf::from("/usr/local/bin/meda"),
+        PathBuf::from(format!("{}/.local/bin/meda", std::env::var("HOME")?)),
+        PathBuf::from(format!("{}/.cargo/bin/meda", std::env::var("HOME")?)),
+    ];
+
+    let mut found_meda = None;
+    for path in &possible_paths {
+        if path.exists() {
+            found_meda = Some(path.clone());
+            info!("Found existing meda installation at {:?}", path);
+            break;
+        }
+    }
+
+    // Also check if meda is in PATH
+    if found_meda.is_none() {
+        if let Ok(output) = Command::new("which").arg("meda").output() {
+            if output.status.success() {
+                let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path_str.is_empty() {
+                    let path = PathBuf::from(path_str);
+                    found_meda = Some(path.clone());
+                    info!("Found meda in PATH at {:?}", path);
+                }
+            }
+        }
+    }
+
+    // If meda is not found anywhere, install it
+    if found_meda.is_none() {
+        info!("Meda not found, installing...");
+
+        // Download and run the installation script
+        info!("Running meda installation script...");
+
+        // Create a temporary directory for the installation
+        let temp_dir = std::env::temp_dir().join("meda_install");
+        if temp_dir.exists() {
+            fs::remove_dir_all(&temp_dir)?;
+        }
+        fs::create_dir_all(&temp_dir)?;
+
+        let install_script = temp_dir.join("install-meda.sh");
+
+        // Download the installation script
+        let status = Command::new("curl")
+            .arg("-fsSL")
+            .arg("https://raw.githubusercontent.com/cirunlabs/meda/main/scripts/install-release.sh")
+            .arg("-o")
+            .arg(&install_script)
+            .status()?;
+
+        if !status.success() {
+            return Err("Failed to download meda installation script".into());
+        }
+
+        // Make the script executable
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&install_script)?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&install_script, perms)?;
+        }
+
+        // Run the installation script
+        let status = Command::new("bash")
+            .arg(&install_script)
+            .env("HOME", std::env::var("HOME")?)
+            .status()?;
+
+        if !status.success() {
+            return Err("Failed to install meda".into());
+        }
+
+        // Verify the binary was installed - check multiple possible locations
+        let home_dir = std::env::var("HOME")?;
+        let possible_install_locations = vec![
+            PathBuf::from(&home_dir).join(".local/bin/meda"),
+            PathBuf::from(&home_dir).join(".cargo/bin/meda"),
+            PathBuf::from("/usr/local/bin/meda"),
+        ];
+
+        let mut installed_meda = None;
+        for location in &possible_install_locations {
+            if location.exists() {
+                installed_meda = Some(location.clone());
+                break;
+            }
+        }
+
+        let installed_meda = installed_meda
+            .ok_or("Meda binary not found after installation in any expected location")?;
+
+        info!("Meda installed successfully at {:?}", installed_meda);
+        found_meda = Some(installed_meda);
+
+        // Clean up the temporary directory
+        fs::remove_dir_all(&temp_dir)?;
+    }
+
+    // Use the found meda binary path
+    let meda_binary = found_meda.ok_or("Meda binary not found")?;
+
+    // Check if meda serve is already running
+    let is_running = Command::new("pgrep")
+        .arg("-f")
+        .arg("meda serve")
+        .stdout(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+
+    if is_running {
+        info!("Meda server is already running");
+    } else {
+        // Run "meda serve" in the background
+        info!("Starting 'meda serve' in the background...");
+
+        // Spawn meda serve as a detached process with output redirected to log files
+        let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        let log_dir = PathBuf::from(&home_dir).join(".meda/logs");
+        fs::create_dir_all(&log_dir).unwrap_or_else(|e| {
+            warn!("Could not create log directory: {}", e);
+        });
+
+        let stdout_log = log_dir.join("meda-stdout.log");
+        let stderr_log = log_dir.join("meda-stderr.log");
+
+        let stdout_file = fs::File::create(&stdout_log).unwrap_or_else(|e| {
+            warn!("Could not create stdout log file: {}", e);
+            fs::File::create("/dev/null").expect("Failed to open /dev/null")
+        });
+
+        let stderr_file = fs::File::create(&stderr_log).unwrap_or_else(|e| {
+            warn!("Could not create stderr log file: {}", e);
+            fs::File::create("/dev/null").expect("Failed to open /dev/null")
+        });
+
+        let child = Command::new(&meda_binary)
+            .arg("serve")
+            .arg("--port")
+            .arg("7777")
+            .stdout(Stdio::from(stdout_file))
+            .stderr(Stdio::from(stderr_file))
+            .spawn()?;
+
+        info!(
+            "Meda server started in the background with PID: {}",
+            child.id()
+        );
+        info!("Meda logs available at {:?}", log_dir);
+
+        // Give meda some time to start
+        thread::sleep(Duration::from_secs(5));
+
+        // Check if the process is still running
+        let is_running = Command::new("ps")
+            .arg("-p")
+            .arg(child.id().to_string())
+            .stdout(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+
+        if !is_running {
+            warn!(
+                "Meda process terminated immediately after starting. Check logs at {:?}",
+                stderr_log
+            );
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
    This commit adds support for spinning up Linux VMs using the meda
    virtualization platform (https://github.com/cirunlabs/meda), which
    wraps Cloud-Hypervisor and supports OCI images.

    Key changes:
    - Added new meda module with client, models, errors, and setup
    - Implemented platform detection to use meda on Linux, lume on macOS
    - Added MedaClient with API methods for VM lifecycle management
    - Created run_script_on_vm_meda helper for SSH provisioning
    - Updated main loop to initialize appropriate VM manager based on OS
    - Split provision_runner into platform-specific implementations
    - Updated VM reporting and deletion to work with both platforms

    Architecture:
    - Lume (macOS): Uses template/clone approach for VM provisioning
    - Meda (Linux): Runs VMs directly from OCI images via API

    The agent now automatically detects the host platform and uses the
    appropriate VM management backend, enabling Linux support while
    maintaining backward compatibility with existing macOS deployments.