### PR TITLE
Handle meda 503 + funnel provision events through a single reporter

### DIFF
--- a/src/cirun_client.rs
+++ b/src/cirun_client.rs
@@ -21,7 +21,12 @@ pub struct CirunClient {
     base_url: String,
     api_token: String,
     agent: AgentInfo,
-    pub retry_tracker: HashMap<String, u32>,
+    /// Per-runner attempt counter. Mutexed for the same reason `in_flight`
+    /// is: the `ProvisionReporter` impl takes `&self`, so internal state
+    /// it mutates needs interior mutability. Lock contention is minimal —
+    /// only one task touches the map at a time in practice (sequential
+    /// `try_join_next` drain).
+    pub retry_tracker: std::sync::Mutex<HashMap<String, u32>>,
     /// None means no limit, Some(n) means max n concurrent VMs
     max_vms: Option<u32>,
     /// Per-runner executor binding, learned at provision time. Cleanup/delete
@@ -52,7 +57,7 @@ impl CirunClient {
             base_url: base_url.to_string(),
             api_token: api_token.to_string(),
             agent,
-            retry_tracker: HashMap::new(),
+            retry_tracker: std::sync::Mutex::new(HashMap::new()),
             max_vms,
             runner_executors: std::sync::Mutex::new(HashMap::new()),
             in_flight: std::sync::Mutex::new(std::collections::HashSet::new()),
@@ -222,24 +227,35 @@ impl CirunClient {
             })
     }
 
-    /// Get the current retry count for a runner
+    /// Get the current retry count for a runner. Returns 0 on a poisoned
+    /// mutex — better to under-report and let the runner be re-tried
+    /// than to crash the agent.
     fn get_retry_count(&self, runner_name: &str) -> u32 {
-        *self.retry_tracker.get(runner_name).unwrap_or(&0)
+        self.retry_tracker
+            .lock()
+            .map(|m| m.get(runner_name).copied().unwrap_or(0))
+            .unwrap_or(0)
     }
 
-    /// Increment the retry count for a runner and return the new count
-    pub fn increment_retry(&mut self, runner_name: &str) -> u32 {
-        let count = self
-            .retry_tracker
-            .entry(runner_name.to_string())
-            .or_insert(0);
-        *count += 1;
-        *count
+    /// Increment the retry count for a runner and return the new count.
+    /// Called from the `ProvisionReporter::report` impl when a runner
+    /// hits a real (non-admission) failure.
+    pub(crate) fn increment_retry(&self, runner_name: &str) -> u32 {
+        match self.retry_tracker.lock() {
+            Ok(mut m) => {
+                let count = m.entry(runner_name.to_string()).or_insert(0);
+                *count += 1;
+                *count
+            }
+            Err(_) => 1, // mutex poisoned; treat as "first attempt"
+        }
     }
 
-    /// Clear the retry count for a runner
-    pub fn clear_retry(&mut self, runner_name: &str) {
-        self.retry_tracker.remove(runner_name);
+    /// Clear the retry count for a runner (success path).
+    pub(crate) fn clear_retry(&self, runner_name: &str) {
+        if let Ok(mut m) = self.retry_tracker.lock() {
+            m.remove(runner_name);
+        }
     }
 
     /// Check if a runner should be retried based on max_retries
@@ -247,8 +263,70 @@ impl CirunClient {
         self.get_retry_count(runner_name) < max_retries
     }
 
-    /// Notify the API that a runner provisioning attempt failed
-    pub async fn notify_provision_failure(&self, runner_name: &str, error: String, attempt: u32) {
+    /// POST a structured `at_capacity` event for a single runner. Called
+    /// from the `ProvisionReporter::report` impl when meda admission
+    /// control returned 503; the backend uses it to render
+    /// "queued, host at capacity" on the GitHub check run instead of
+    /// "failed". `pub(crate)` because the public entry point is now
+    /// `<Self as ProvisionReporter>::report` — direct callers would
+    /// bypass the retry-budget policy.
+    pub(crate) async fn notify_at_capacity(
+        &self,
+        runner_name: &str,
+        code: &str,
+        message: &str,
+        retry_after_secs: u64,
+    ) {
+        let url = format!("{}/agent", self.base_url);
+
+        info!(
+            "Notifying API host at capacity for {}: {} ({}). Retry-After {}s",
+            runner_name, message, code, retry_after_secs
+        );
+
+        let request_data = json!({
+            "agent": self.agent,
+            "at_capacity": {
+                "runner_name": runner_name,
+                "code": code,
+                "message": message,
+                "retry_after_secs": retry_after_secs,
+            }
+        });
+
+        match self
+            .create_request(reqwest::Method::POST, &url)
+            .json(&request_data)
+            .send()
+            .await
+        {
+            Ok(response) => {
+                if response.status().is_success() {
+                    debug!("Successfully notified API of at-capacity event");
+                } else {
+                    warn!(
+                        "API returned non-success status for at-capacity notification: {}",
+                        response.status()
+                    );
+                }
+            }
+            Err(e) => {
+                warn!("Failed to notify API of at-capacity event: {}", e);
+            }
+        }
+    }
+
+    /// POST a `provision_failure` event for a single runner. Called from
+    /// the `ProvisionReporter::report` impl after `increment_retry` has
+    /// bumped the per-runner counter. `pub(crate)` — direct callers
+    /// would bypass the retry-counter increment that's coupled to this
+    /// event.
+    pub(crate) async fn notify_provision_failure(
+        &self,
+        runner_name: &str,
+        error: String,
+        attempt: u32,
+    ) {
         let url = format!("{}/agent", self.base_url);
 
         info!(
@@ -498,6 +576,48 @@ impl CirunClient {
     }
 }
 
+/// `ProvisionReporter` is the agent's single funnel for provision-outcome
+/// observability (see `src/reporting.rs`). Every per-event policy
+/// decision (which HTTP payload to send, whether to touch the retry
+/// counter) lives in this impl — main.rs just calls `report(event)`.
+///
+/// Adding a new event type means: add a variant in `ProvisionEvent`,
+/// add a match arm here. main.rs does not change.
+#[async_trait::async_trait]
+impl crate::reporting::ProvisionReporter for CirunClient {
+    async fn report(&self, event: crate::reporting::ProvisionEvent) {
+        use crate::reporting::ProvisionEvent;
+        match event {
+            ProvisionEvent::Succeeded { runner_name } => {
+                // No HTTP notify: the SaaS learns about the running
+                // runner via the periodic `report_running_vms` POST.
+                // Clearing the retry counter is the local-state half
+                // of "this runner is now healthy on this agent".
+                self.clear_retry(&runner_name);
+            }
+            ProvisionEvent::Failed { runner_name, error } => {
+                let attempt = self.increment_retry(&runner_name);
+                self.notify_provision_failure(&runner_name, error, attempt)
+                    .await;
+            }
+            ProvisionEvent::AtCapacity {
+                runner_name,
+                code,
+                message,
+                retry_after_secs,
+            } => {
+                // Intentionally NOT incrementing the retry counter —
+                // admission-control denial means the runner was never
+                // spawned, so it shouldn't count against the runner's
+                // `max_retries`. The runner stays in the SaaS's
+                // `requested` pool and re-fans on the next poll.
+                self.notify_at_capacity(&runner_name, &code, &message, retry_after_secs)
+                    .await;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -557,7 +677,7 @@ mod tests {
                 os: "linux".into(),
                 arch: "x86_64".into(),
             },
-            retry_tracker: HashMap::new(),
+            retry_tracker: std::sync::Mutex::new(HashMap::new()),
             max_vms: None,
             runner_executors: std::sync::Mutex::new(HashMap::new()),
             in_flight: std::sync::Mutex::new(std::collections::HashSet::new()),

--- a/src/cirun_client.rs
+++ b/src/cirun_client.rs
@@ -263,35 +263,29 @@ impl CirunClient {
         self.get_retry_count(runner_name) < max_retries
     }
 
-    /// POST a structured `at_capacity` event for a single runner. Called
-    /// from the `ProvisionReporter::report` impl when meda admission
-    /// control returned 503; the backend uses it to render
-    /// "queued, host at capacity" on the GitHub check run instead of
-    /// "failed". `pub(crate)` because the public entry point is now
-    /// `<Self as ProvisionReporter>::report` — direct callers would
-    /// bypass the retry-budget policy.
-    pub(crate) async fn notify_at_capacity(
-        &self,
-        runner_name: &str,
-        code: &str,
-        message: &str,
-        retry_after_secs: u64,
-    ) {
+    /// POST a generic `AgentEvent` to the cirun-go backend. ONE entry
+    /// point for all agent → backend observability — cirun-go reads
+    /// `event.kind` and dispatches per its own action table (update
+    /// check run, bump DB retry counter, log, …). Adding a new event
+    /// kind on the agent side means: add an `EventKind` variant in
+    /// `src/reporting.rs`, add a `to_agent_event` arm, mirror the kind
+    /// string on cirun-go. No new HTTP route. No new payload schema.
+    ///
+    /// `pub(crate)` because the public entry point is the
+    /// `ProvisionReporter::report` trait method; direct callers would
+    /// bypass the retry-counter policy that's coupled to certain
+    /// event kinds.
+    pub(crate) async fn notify_event(&self, event: &crate::reporting::AgentEvent) {
         let url = format!("{}/agent", self.base_url);
 
         info!(
-            "Notifying API host at capacity for {}: {} ({}). Retry-After {}s",
-            runner_name, message, code, retry_after_secs
+            "Emitting agent event runner={} kind={:?} severity={:?}: {}",
+            event.runner_name, event.kind, event.severity, event.title
         );
 
         let request_data = json!({
             "agent": self.agent,
-            "at_capacity": {
-                "runner_name": runner_name,
-                "code": code,
-                "message": message,
-                "retry_after_secs": retry_after_secs,
-            }
+            "event": event,
         });
 
         match self
@@ -302,65 +296,16 @@ impl CirunClient {
         {
             Ok(response) => {
                 if response.status().is_success() {
-                    debug!("Successfully notified API of at-capacity event");
+                    debug!("Successfully posted agent event");
                 } else {
                     warn!(
-                        "API returned non-success status for at-capacity notification: {}",
+                        "API returned non-success status for agent event: {}",
                         response.status()
                     );
                 }
             }
             Err(e) => {
-                warn!("Failed to notify API of at-capacity event: {}", e);
-            }
-        }
-    }
-
-    /// POST a `provision_failure` event for a single runner. Called from
-    /// the `ProvisionReporter::report` impl after `increment_retry` has
-    /// bumped the per-runner counter. `pub(crate)` — direct callers
-    /// would bypass the retry-counter increment that's coupled to this
-    /// event.
-    pub(crate) async fn notify_provision_failure(
-        &self,
-        runner_name: &str,
-        error: String,
-        attempt: u32,
-    ) {
-        let url = format!("{}/agent", self.base_url);
-
-        info!(
-            "Notifying API of provisioning failure for {} (attempt {})",
-            runner_name, attempt
-        );
-
-        let request_data = json!({
-            "agent": self.agent,
-            "provision_failure": {
-                "runner_name": runner_name,
-                "error": error,
-                "attempt": attempt,
-            }
-        });
-
-        match self
-            .create_request(reqwest::Method::POST, &url)
-            .json(&request_data)
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status().is_success() {
-                    debug!("Successfully notified API of provisioning failure");
-                } else {
-                    warn!(
-                        "API returned non-success status for failure notification: {}",
-                        response.status()
-                    );
-                }
-            }
-            Err(e) => {
-                warn!("Failed to notify API of provisioning failure: {}", e);
+                warn!("Failed to post agent event: {}", e);
             }
         }
     }
@@ -440,7 +385,10 @@ impl CirunClient {
                 json.runners_to_provision.len()
             );
 
-            // First, handle retry-exhausted runners (notify API, skip them)
+            // First, handle retry-exhausted runners (notify API, skip them).
+            // Same agent-event funnel used elsewhere: emit a
+            // ProvisionEvent::Failed and let the reporter impl build the
+            // wire payload so cirun-go gets the consistent shape.
             for runner in &json.runners_to_provision {
                 let current_attempts = self.get_retry_count(&runner.name);
                 if !self.should_retry(&runner.name, runner.max_retries) {
@@ -448,11 +396,11 @@ impl CirunClient {
                         "Runner '{}' has exceeded max retries ({}/{}). Skipping provisioning.",
                         runner.name, current_attempts, runner.max_retries
                     );
-                    self.notify_provision_failure(
-                        &runner.name,
-                        format!("Exceeded max retries ({})", runner.max_retries),
-                        current_attempts,
-                    )
+                    use crate::reporting::ProvisionReporter;
+                    self.report(crate::reporting::ProvisionEvent::Failed {
+                        runner_name: runner.name.clone(),
+                        error: format!("Exceeded max retries ({})", runner.max_retries),
+                    })
                     .await;
                 }
             }
@@ -586,34 +534,29 @@ impl CirunClient {
 #[async_trait::async_trait]
 impl crate::reporting::ProvisionReporter for CirunClient {
     async fn report(&self, event: crate::reporting::ProvisionEvent) {
-        use crate::reporting::ProvisionEvent;
-        match event {
+        use crate::reporting::{to_agent_event, ProvisionEvent};
+
+        // Per-event POLICY: retry-counter mutation. AtCapacity does NOT
+        // increment because the runner was never spawned (admission
+        // denial); the runner stays in the SaaS's `requested` pool to
+        // be re-fanned on the next poll. Succeeded clears any prior
+        // retry state. Failed bumps the counter for max_retries
+        // accounting and the attempt number rides on the wire event.
+        let attempt = match &event {
             ProvisionEvent::Succeeded { runner_name } => {
-                // No HTTP notify: the SaaS learns about the running
-                // runner via the periodic `report_running_vms` POST.
-                // Clearing the retry counter is the local-state half
-                // of "this runner is now healthy on this agent".
-                self.clear_retry(&runner_name);
+                self.clear_retry(runner_name);
+                0
             }
-            ProvisionEvent::Failed { runner_name, error } => {
-                let attempt = self.increment_retry(&runner_name);
-                self.notify_provision_failure(&runner_name, error, attempt)
-                    .await;
-            }
-            ProvisionEvent::AtCapacity {
-                runner_name,
-                code,
-                message,
-                retry_after_secs,
-            } => {
-                // Intentionally NOT incrementing the retry counter —
-                // admission-control denial means the runner was never
-                // spawned, so it shouldn't count against the runner's
-                // `max_retries`. The runner stays in the SaaS's
-                // `requested` pool and re-fans on the next poll.
-                self.notify_at_capacity(&runner_name, &code, &message, retry_after_secs)
-                    .await;
-            }
+            ProvisionEvent::Failed { runner_name, .. } => self.increment_retry(runner_name),
+            ProvisionEvent::AtCapacity { .. } => 0,
+        };
+
+        // WIRE: build the generic AgentEvent and post it through the
+        // single observability funnel. Succeeded returns None today —
+        // the running-VMs heartbeat already tells SaaS the runner is up,
+        // so we skip the wire emit to avoid duplicate check-run noise.
+        if let Some(agent_event) = to_agent_event(&event, attempt) {
+            self.notify_event(&agent_event).await;
         }
     }
 }

--- a/src/docker/client.rs
+++ b/src/docker/client.rs
@@ -29,6 +29,7 @@ impl DockerClient {
     }
 
     #[cfg(test)]
+    #[allow(dead_code)] // Reserved for future tests that need a non-default docker binary path.
     pub fn with_bin(bin: impl Into<String>) -> Self {
         Self { bin: bin.into() }
     }

--- a/src/executor/meda.rs
+++ b/src/executor/meda.rs
@@ -181,10 +181,7 @@ async fn push_provision_script_via_ssh(
     let (timeout_secs, cmd) = if run_detached {
         (
             60u64,
-            format!(
-                "chmod +x {p} && sudo nohup bash {p} > /tmp/script_stdout.log 2> /tmp/script_stderr.log & echo $!",
-                p = remote_path
-            ),
+            crate::script_cmd::detached_provision_cmd(&remote_path, true),
         )
     } else {
         (

--- a/src/executor/meda.rs
+++ b/src/executor/meda.rs
@@ -57,10 +57,23 @@ impl Executor for MedaExecutor {
             cpus: Some(spec.cpu),
             disk_size: Some(format!("{}G", spec.disk_gb)),
         };
-        self.client
-            .run_vm(req)
-            .await
-            .map_err(|e| ProvisionError::Transient(format!("meda run_vm: {e:?}")))
+        // Map admission-control 503s onto ProvisionError::HostFull so
+        // the provision flow can signal "at capacity" upstream without
+        // burning the runner's retry budget. Other meda errors are
+        // genuine failures and stay as Transient.
+        match self.client.run_vm(req).await {
+            Ok(()) => Ok(()),
+            Err(crate::meda::errors::MedaError::HostFull {
+                code,
+                message,
+                retry_after_secs,
+            }) => Err(ProvisionError::HostFull {
+                code,
+                message,
+                retry_after_secs,
+            }),
+            Err(e) => Err(ProvisionError::Transient(format!("meda run_vm: {e:?}"))),
+        }
     }
 
     async fn kill(&self, name: &str) -> Result<(), ProvisionError> {

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -168,6 +168,19 @@ pub enum ProvisionError {
     /// Spec is incompatible with this executor (e.g. lume + GPU). Never retry.
     #[error("incompatible: {0}")]
     Incompatible(String),
+    /// Underlying host (meda's admission control today) is at capacity.
+    /// The caller MUST NOT count this against the runner's retry budget
+    /// and SHOULD signal upstream so the backend can mark the GH check
+    /// run as "queued, host at capacity" rather than "provisioning
+    /// failed". The runner stays in the backend's `requested` pool and
+    /// gets re-fanned on the next poll.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    #[error("host_full ({code}): {message}")]
+    HostFull {
+        code: String,
+        message: String,
+        retry_after_secs: u64,
+    },
 }
 
 #[async_trait]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod lume;
 #[cfg(target_os = "linux")]
 mod meda;
 mod provision;
+mod reporting;
 mod service;
 mod ssh;
 #[cfg(target_os = "macos")]
@@ -245,18 +246,16 @@ async fn main() {
                             map.insert(pr.runner_name.clone(), kind);
                         }
                     }
-                    match pr.outcome {
-                        Ok(()) => {
-                            client.clear_retry(&pr.runner_name);
-                            any_provision_succeeded = true;
-                        }
-                        Err(error_msg) => {
-                            let attempt = client.increment_retry(&pr.runner_name);
-                            client
-                                .notify_provision_failure(&pr.runner_name, error_msg, attempt)
-                                .await;
-                        }
+                    // All per-outcome dispatch (retry math, which HTTP
+                    // payload to send) lives in the ProvisionReporter
+                    // impl on CirunClient. main.rs just lifts the
+                    // outcome into the event vocabulary and emits.
+                    let event = crate::reporting::ProvisionEvent::from(pr);
+                    if event.is_success() {
+                        any_provision_succeeded = true;
                     }
+                    use crate::reporting::ProvisionReporter;
+                    client.report(event).await;
                 }
                 Err(e) => {
                     error!("Provisioning task panicked: {}", e);
@@ -323,6 +322,7 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(test, target_os = "macos"))]
     use super::*;
     use crate::bootstrap::{get_agent_info, get_hostname};
     // generate_template_name lives in crate::lume which is macos-only.

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod lume;
 mod meda;
 mod provision;
 mod reporting;
+mod script_cmd;
 mod service;
 mod ssh;
 #[cfg(target_os = "macos")]

--- a/src/meda/client.rs
+++ b/src/meda/client.rs
@@ -1,6 +1,6 @@
 use backon::{ExponentialBuilder, Retryable};
 use log::{info, warn};
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
 use std::time::Duration;
 
 use crate::meda::errors::MedaError;
@@ -11,6 +11,52 @@ use crate::meda::models::{
 const DEFAULT_API_URL: &str = "http://127.0.0.1:7777/api/v1";
 const CONNECT_TIMEOUT: u64 = 10; // 10 seconds
 const MAX_TIMEOUT: u64 = 300; // 5 minutes
+const DEFAULT_RETRY_AFTER_SECS: u64 = 10;
+
+/// Classify a meda `POST /images/run` response into Ok / HostFull / other
+/// ApiError. Pure: takes only the raw bits the HTTP layer hands us
+/// (status code, Retry-After header value, body text), so the run_vm
+/// loop stays small and the policy is independently testable.
+///
+/// 503 is meda's admission-control denial — the host can't take another
+/// VM right now. The body is a JSON ApiError with `code` =
+/// MEM_EXHAUSTED / CPU_EXHAUSTED / DISK_EXHAUSTED and `error` =
+/// operator-readable detail. We expose both via MedaError::HostFull so
+/// the executor + provision flow can treat it as backpressure (don't
+/// burn the retry budget, ask the backend to mark the runner "at
+/// capacity") rather than a real failure.
+pub(crate) fn classify_run_vm_response(
+    status: StatusCode,
+    retry_after: Option<&str>,
+    body: &str,
+) -> Result<(), MedaError> {
+    if status.is_success() {
+        return Ok(());
+    }
+    if status == StatusCode::SERVICE_UNAVAILABLE {
+        let parsed: serde_json::Value =
+            serde_json::from_str(body).unwrap_or(serde_json::Value::Null);
+        let code = parsed
+            .get("code")
+            .and_then(|v| v.as_str())
+            .unwrap_or("HOST_FULL")
+            .to_string();
+        let message = parsed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Host at capacity")
+            .to_string();
+        let retry_after_secs = retry_after
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_RETRY_AFTER_SECS);
+        return Err(MedaError::HostFull {
+            code,
+            message,
+            retry_after_secs,
+        });
+    }
+    Err(MedaError::ApiError(format!("Failed to run VM: {}", body)))
+}
 
 pub struct MedaClient {
     client: Client,
@@ -73,6 +119,11 @@ impl MedaClient {
 
         let response = self.client.post(&url).json(&config).send().await?;
         let status = response.status();
+        let retry_after = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
         let response_text = response
             .text()
             .await
@@ -83,12 +134,7 @@ impl MedaClient {
             status, response_text
         );
 
-        if !status.is_success() {
-            return Err(MedaError::ApiError(format!(
-                "Failed to run VM: {}",
-                response_text
-            )));
-        }
+        classify_run_vm_response(status, retry_after.as_deref(), &response_text)?;
 
         info!("Successfully started VM from image: {}", config.image);
         Ok(())
@@ -275,6 +321,105 @@ impl MedaClient {
             }
 
             tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifier_passes_2xx_through() {
+        assert!(classify_run_vm_response(StatusCode::OK, None, "{}").is_ok());
+        assert!(classify_run_vm_response(StatusCode::CREATED, None, "anything").is_ok());
+    }
+
+    #[test]
+    fn classifier_maps_503_with_full_apierror_body_to_host_full() {
+        // Meda PR 7 returns ApiError JSON on admission denial. We must
+        // surface the structured code so cirun-go can present a useful
+        // GH check-run message ("Host at capacity: CPU exhausted" not
+        // a generic "provision failed").
+        let body = r#"{"error":"CPU exhausted: need 4 vCPU, 3 vCPU available after reserve","code":"CPU_EXHAUSTED","details":null}"#;
+        match classify_run_vm_response(StatusCode::SERVICE_UNAVAILABLE, Some("10"), body) {
+            Err(MedaError::HostFull {
+                code,
+                message,
+                retry_after_secs,
+            }) => {
+                assert_eq!(code, "CPU_EXHAUSTED");
+                assert!(message.contains("CPU exhausted"));
+                assert_eq!(retry_after_secs, 10);
+            }
+            other => panic!("expected HostFull, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifier_503_without_retry_after_uses_default() {
+        // Meda always sends Retry-After today, but a future operator
+        // could disable it via a proxy. Don't blow up — fall back to a
+        // sensible 10s default that matches the server's intent.
+        let body = r#"{"error":"mem","code":"MEM_EXHAUSTED"}"#;
+        match classify_run_vm_response(StatusCode::SERVICE_UNAVAILABLE, None, body) {
+            Err(MedaError::HostFull {
+                retry_after_secs, ..
+            }) => assert_eq!(retry_after_secs, DEFAULT_RETRY_AFTER_SECS),
+            other => panic!("expected HostFull, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifier_503_with_unparseable_retry_after_uses_default() {
+        // RFC 7231 allows Retry-After to be an HTTP-date too, but we
+        // don't parse those. On any non-numeric value, fall back.
+        let body = r#"{"error":"x","code":"DISK_EXHAUSTED"}"#;
+        match classify_run_vm_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            Some("Wed, 16 May 2026 04:00:00 GMT"),
+            body,
+        ) {
+            Err(MedaError::HostFull {
+                retry_after_secs, ..
+            }) => assert_eq!(retry_after_secs, DEFAULT_RETRY_AFTER_SECS),
+            other => panic!("expected HostFull, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifier_503_with_non_json_body_still_classifies_as_host_full() {
+        // A proxy 503 may not be JSON. We still know it's backpressure
+        // (status code is authoritative) and use sane code/message
+        // defaults rather than dropping it into the generic ApiError
+        // bucket — that bucket triggers a real failure notify.
+        match classify_run_vm_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            Some("5"),
+            "Service Unavailable",
+        ) {
+            Err(MedaError::HostFull {
+                code,
+                message,
+                retry_after_secs,
+            }) => {
+                assert_eq!(code, "HOST_FULL");
+                assert_eq!(message, "Host at capacity");
+                assert_eq!(retry_after_secs, 5);
+            }
+            other => panic!("expected HostFull, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifier_500_stays_as_generic_apierror() {
+        // Real meda errors (panics, DB problems) must NOT be classified
+        // as backpressure — those need to fail the runner and burn a
+        // retry slot so we surface the bug to the operator.
+        let body = r#"{"error":"panic","code":"INTERNAL"}"#;
+        match classify_run_vm_response(StatusCode::INTERNAL_SERVER_ERROR, None, body) {
+            Err(MedaError::ApiError(msg)) => assert!(msg.contains("panic")),
+            other => panic!("expected ApiError, got {other:?}"),
         }
     }
 }

--- a/src/meda/errors.rs
+++ b/src/meda/errors.rs
@@ -6,6 +6,18 @@ use std::fmt;
 pub enum MedaError {
     RequestError(ReqwestError),
     ApiError(String),
+    /// Meda admission-control rejection (HTTP 503). Distinguished from
+    /// ApiError because the caller MUST treat it as transient
+    /// backpressure rather than a real provision failure — the host is
+    /// at capacity, not broken. `code` is the structured reason
+    /// (MEM_EXHAUSTED / CPU_EXHAUSTED / DISK_EXHAUSTED), `message` is
+    /// meda's operator-facing detail string, `retry_after_secs` comes
+    /// from the response's Retry-After header (10 by meda default).
+    HostFull {
+        code: String,
+        message: String,
+        retry_after_secs: u64,
+    },
 }
 
 impl fmt::Display for MedaError {
@@ -13,6 +25,14 @@ impl fmt::Display for MedaError {
         match self {
             MedaError::RequestError(err) => write!(f, "Request error: {}", err),
             MedaError::ApiError(msg) => write!(f, "API error: {}", msg),
+            MedaError::HostFull {
+                code,
+                message,
+                retry_after_secs,
+            } => write!(
+                f,
+                "Host at capacity ({code}): {message} (retry after {retry_after_secs}s)"
+            ),
         }
     }
 }
@@ -21,7 +41,7 @@ impl StdError for MedaError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             MedaError::RequestError(err) => Some(err),
-            MedaError::ApiError(_) => None,
+            MedaError::ApiError(_) | MedaError::HostFull { .. } => None,
         }
     }
 }

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -17,13 +17,36 @@ use log::{error, info};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
+/// Outcome of a single runner provisioning attempt. Distinguishes three
+/// cases that the main loop must treat differently:
+///
+/// - `Success` — runner is up and registered; clear retry count.
+/// - `Failed` — real failure (executor error, bad spec, network). Burn
+///   a retry slot and notify the backend so SaaS can mark the runner
+///   failed (or retry it depending on `max_retries`).
+/// - `HostFull` — meda admission control denied the request because
+///   the host is at capacity. The runner was NEVER spawned; we MUST
+///   NOT count this against `max_retries` and we SHOULD push the
+///   structured reason upstream so the backend can surface "queued,
+///   host at capacity" on the GitHub check run instead of "failed".
+pub enum ProvisionOutcome {
+    Success,
+    Failed(String),
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    HostFull {
+        code: String,
+        message: String,
+        retry_after_secs: u64,
+    },
+}
+
 /// Result of a single runner provisioning attempt
 pub struct ProvisionResult {
     pub runner_name: String,
     /// Executor that handled the runner. `None` when derivation failed
     /// (we never started provisioning).
     pub executor_kind: Option<crate::executor::ExecutorKind>,
-    pub outcome: Result<(), String>,
+    pub outcome: ProvisionOutcome,
 }
 
 /// Provision a single runner in its own task. Acquires a semaphore permit to
@@ -86,7 +109,7 @@ pub async fn provision_single_runner(
             return ProvisionResult {
                 runner_name: runner.name.clone(),
                 executor_kind: None,
-                outcome: Err(format!("Cannot derive executor: {e}")),
+                outcome: ProvisionOutcome::Failed(format!("Cannot derive executor: {e}")),
             };
         }
     };
@@ -132,7 +155,10 @@ pub async fn provision_single_runner(
                             return ProvisionResult {
                                 runner_name: runner.name.clone(),
                                 executor_kind: Some(executor_kind),
-                                outcome: Err(format!("Template creation failed: {}", e)),
+                                outcome: ProvisionOutcome::Failed(format!(
+                                    "Template creation failed: {}",
+                                    e
+                                )),
                             };
                         }
                     }
@@ -158,7 +184,7 @@ pub async fn provision_single_runner(
             return ProvisionResult {
                 runner_name: runner.name.clone(),
                 executor_kind: Some(executor_kind),
-                outcome: Err("No template available".to_string()),
+                outcome: ProvisionOutcome::Failed("No template available".to_string()),
             };
         }
     };
@@ -192,7 +218,7 @@ pub async fn provision_single_runner(
             return ProvisionResult {
                 runner_name: runner.name.clone(),
                 executor_kind: Some(executor_kind),
-                outcome: Err(format!("Invalid gpu request: {e}")),
+                outcome: ProvisionOutcome::Failed(format!("Invalid gpu request: {e}")),
             };
         }
     };
@@ -214,34 +240,56 @@ pub async fn provision_single_runner(
     // Dispatch through the host registry (probed at startup) so a backend
     // that wasn't reachable then doesn't get a late attempt against a fresh
     // client.
-    let result: Result<(), String> = match registry.get(executor_kind) {
-        Ok(exec) => exec.provision(&spec).await.map_err(|e| e.to_string()),
-        Err(e) => Err(e.to_string()),
-    };
-
-    match result {
-        Ok(()) => {
-            info!(
-                "Successfully provisioned runner: {} using template {}",
-                runner.name, template_name
-            );
-            ProvisionResult {
-                runner_name: runner.name.clone(),
-                executor_kind: Some(executor_kind),
-                outcome: Ok(()),
+    let outcome = match registry.get(executor_kind) {
+        Ok(exec) => match exec.provision(&spec).await {
+            Ok(()) => {
+                info!(
+                    "Successfully provisioned runner: {} using template {}",
+                    runner.name, template_name
+                );
+                ProvisionOutcome::Success
             }
-        }
+            // HostFull is admission backpressure, NOT a real failure.
+            // Preserve the structured reason so the main loop can route
+            // it to `notify_at_capacity` instead of burning a retry
+            // slot via `notify_provision_failure`.
+            Err(crate::executor::ProvisionError::HostFull {
+                code,
+                message,
+                retry_after_secs,
+            }) => {
+                info!(
+                    "Host at capacity for runner {}: {} ({}). Retry-After {}s",
+                    runner.name, message, code, retry_after_secs
+                );
+                ProvisionOutcome::HostFull {
+                    code,
+                    message,
+                    retry_after_secs,
+                }
+            }
+            Err(e) => {
+                let error_msg = e.to_string();
+                error!(
+                    "Failed to provision runner {} using template {}: {}",
+                    runner.name, template_name, error_msg
+                );
+                ProvisionOutcome::Failed(error_msg)
+            }
+        },
         Err(e) => {
             let error_msg = e.to_string();
             error!(
-                "Failed to provision runner {} using template {}: {}",
-                runner.name, template_name, error_msg
+                "Failed to provision runner {} (registry lookup): {}",
+                runner.name, error_msg
             );
-            ProvisionResult {
-                runner_name: runner.name.clone(),
-                executor_kind: Some(executor_kind),
-                outcome: Err(error_msg),
-            }
+            ProvisionOutcome::Failed(error_msg)
         }
+    };
+
+    ProvisionResult {
+        runner_name: runner.name.clone(),
+        executor_kind: Some(executor_kind),
+        outcome,
     }
 }

--- a/src/reporting.rs
+++ b/src/reporting.rs
@@ -1,0 +1,219 @@
+//! Single funnel for provision-outcome observability.
+//!
+//! The agent's main loop produces `ProvisionResult`s; each one needs to:
+//!   - mutate per-runner retry state (clear on success, increment on
+//!     real failure, **not** touch it on host-full backpressure)
+//!   - notify the cirun backend with a payload shape that depends on
+//!     which case we're in, so the backend can render the right
+//!     GitHub check-run status (success / failed / queued-at-capacity)
+//!
+//! Without this module the main loop owned all three of those concerns
+//! inline. That made it 20+ lines of arms per outcome, and each new
+//! variant (host-full, future RunnerHealthChanged, …) grew the loop
+//! and the test surface around it. The module here exposes ONE entry
+//! point — `ProvisionReporter::report` — and hides the dispatch:
+//!
+//! ```ignore
+//! reporter.report(ProvisionEvent::from(pr)).await;
+//! ```
+//!
+//! New outcome types add an enum variant + a match arm in the impl on
+//! `CirunClient`. main.rs does not change.
+//!
+//! Retry-counter mutation stays on `CirunClient` (its natural owner —
+//! same struct holds the HTTP binding), but every call to
+//! increment/clear flows through the reporter impl. main.rs has no
+//! business touching the counter, and now it doesn't.
+
+use async_trait::async_trait;
+
+use crate::provision::{ProvisionOutcome, ProvisionResult};
+
+/// Vocabulary of provision-outcome events the agent emits upstream.
+///
+/// Each variant carries exactly what the corresponding cirun backend
+/// payload needs — the reporter impl translates 1:1, no shape-shifting
+/// at the call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProvisionEvent {
+    /// Runner provisioned and registered with GitHub. Reporter clears
+    /// retry state; no HTTP notification needed (the SaaS learns via
+    /// the periodic `report_running_vms` POST that this runner is now
+    /// alive on the agent).
+    Succeeded { runner_name: String },
+
+    /// Real provisioning failure (executor error, bad spec, network).
+    /// Reporter increments retry count and POSTs a `provision_failure`
+    /// payload so the backend can decide retry vs. mark-failed based
+    /// on `max_retries`.
+    Failed { runner_name: String, error: String },
+
+    /// Host admission control rejected the request (meda 503). The
+    /// runner was NEVER spawned, so retry budget MUST be preserved.
+    /// Reporter posts an `at_capacity` payload carrying the structured
+    /// reason (CPU_EXHAUSTED / MEM_EXHAUSTED / DISK_EXHAUSTED) so the
+    /// backend can surface "queued, host at capacity" on the GitHub
+    /// check run instead of "failed".
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    AtCapacity {
+        runner_name: String,
+        code: String,
+        message: String,
+        retry_after_secs: u64,
+    },
+}
+
+impl ProvisionEvent {
+    /// True when the agent should consider this a successful provision
+    /// for purposes of "do we need to call report_running_vms now?".
+    /// Kept on the event (not the outcome) so the main loop reads the
+    /// same vocabulary it dispatches with.
+    pub fn is_success(&self) -> bool {
+        matches!(self, ProvisionEvent::Succeeded { .. })
+    }
+}
+
+impl From<ProvisionResult> for ProvisionEvent {
+    fn from(pr: ProvisionResult) -> Self {
+        match pr.outcome {
+            ProvisionOutcome::Success => ProvisionEvent::Succeeded {
+                runner_name: pr.runner_name,
+            },
+            ProvisionOutcome::Failed(error) => ProvisionEvent::Failed {
+                runner_name: pr.runner_name,
+                error,
+            },
+            ProvisionOutcome::HostFull {
+                code,
+                message,
+                retry_after_secs,
+            } => ProvisionEvent::AtCapacity {
+                runner_name: pr.runner_name,
+                code,
+                message,
+                retry_after_secs,
+            },
+        }
+    }
+}
+
+/// Sink for provision-outcome events. The single trait method is the
+/// reporter's whole public surface — callers compose dispatch by
+/// pattern-matching `ProvisionEvent` arms inside the impl, not by
+/// memorizing a fan of `notify_*` method names.
+#[async_trait]
+pub trait ProvisionReporter: Send + Sync {
+    async fn report(&self, event: ProvisionEvent);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Test double that records every event in arrival order. Lets the
+    /// main-loop tests assert "the reporter saw exactly these events
+    /// in this order" without spinning up HTTP.
+    pub struct RecordingReporter {
+        events: Mutex<Vec<ProvisionEvent>>,
+    }
+
+    impl RecordingReporter {
+        pub fn new() -> Self {
+            Self {
+                events: Mutex::new(Vec::new()),
+            }
+        }
+        pub fn events(&self) -> Vec<ProvisionEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl ProvisionReporter for RecordingReporter {
+        async fn report(&self, event: ProvisionEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    fn pr_success(name: &str) -> ProvisionResult {
+        ProvisionResult {
+            runner_name: name.into(),
+            executor_kind: None,
+            outcome: ProvisionOutcome::Success,
+        }
+    }
+
+    fn pr_failed(name: &str, err: &str) -> ProvisionResult {
+        ProvisionResult {
+            runner_name: name.into(),
+            executor_kind: None,
+            outcome: ProvisionOutcome::Failed(err.into()),
+        }
+    }
+
+    fn pr_host_full(name: &str, code: &str) -> ProvisionResult {
+        ProvisionResult {
+            runner_name: name.into(),
+            executor_kind: None,
+            outcome: ProvisionOutcome::HostFull {
+                code: code.into(),
+                message: format!("{code} test"),
+                retry_after_secs: 10,
+            },
+        }
+    }
+
+    #[test]
+    fn lifts_success_outcome_to_succeeded_event() {
+        let ev: ProvisionEvent = pr_success("r1").into();
+        assert_eq!(
+            ev,
+            ProvisionEvent::Succeeded {
+                runner_name: "r1".into()
+            }
+        );
+        assert!(ev.is_success());
+    }
+
+    #[test]
+    fn lifts_failed_outcome_to_failed_event() {
+        let ev: ProvisionEvent = pr_failed("r1", "boom").into();
+        assert_eq!(
+            ev,
+            ProvisionEvent::Failed {
+                runner_name: "r1".into(),
+                error: "boom".into()
+            }
+        );
+        assert!(!ev.is_success());
+    }
+
+    #[test]
+    fn lifts_host_full_outcome_to_at_capacity_event() {
+        let ev: ProvisionEvent = pr_host_full("r1", "CPU_EXHAUSTED").into();
+        assert_eq!(
+            ev,
+            ProvisionEvent::AtCapacity {
+                runner_name: "r1".into(),
+                code: "CPU_EXHAUSTED".into(),
+                message: "CPU_EXHAUSTED test".into(),
+                retry_after_secs: 10,
+            }
+        );
+        assert!(!ev.is_success());
+    }
+
+    #[tokio::test]
+    async fn recording_reporter_captures_events_in_order() {
+        // Sanity check the test double itself — if this drifts, every
+        // downstream test that uses RecordingReporter silently breaks.
+        let r = RecordingReporter::new();
+        r.report(pr_success("r1").into()).await;
+        r.report(pr_failed("r2", "x").into()).await;
+        let evs = r.events();
+        assert_eq!(evs.len(), 2);
+        assert!(matches!(evs[0], ProvisionEvent::Succeeded { .. }));
+        assert!(matches!(evs[1], ProvisionEvent::Failed { .. }));
+    }
+}

--- a/src/reporting.rs
+++ b/src/reporting.rs
@@ -1,59 +1,46 @@
-//! Single funnel for provision-outcome observability.
+//! Single funnel for everything the agent wants the cirun backend to
+//! observe.
 //!
-//! The agent's main loop produces `ProvisionResult`s; each one needs to:
-//!   - mutate per-runner retry state (clear on success, increment on
-//!     real failure, **not** touch it on host-full backpressure)
-//!   - notify the cirun backend with a payload shape that depends on
-//!     which case we're in, so the backend can render the right
-//!     GitHub check-run status (success / failed / queued-at-capacity)
+//! Design intent:
 //!
-//! Without this module the main loop owned all three of those concerns
-//! inline. That made it 20+ lines of arms per outcome, and each new
-//! variant (host-full, future RunnerHealthChanged, …) grew the loop
-//! and the test surface around it. The module here exposes ONE entry
-//! point — `ProvisionReporter::report` — and hides the dispatch:
+//! 1. **One wire format.** The agent emits a single generic shape —
+//!    `AgentEvent` — for every observable thing (a runner provisioned,
+//!    a runner failed, a host hit admission-control backpressure, a
+//!    future runner-health change, …). cirun-go consumes one schema and
+//!    decides what to do with each `kind` via its own lookup table.
+//!    Adding a new event type means adding an `EventKind` variant on
+//!    both sides; no new endpoint, no new payload shape.
 //!
-//! ```ignore
-//! reporter.report(ProvisionEvent::from(pr)).await;
-//! ```
+//! 2. **One funnel.** The agent's main loop talks to ONE entry point:
+//!    `ProvisionReporter::report(event)`. The per-event policy (which
+//!    HTTP call, whether to touch retry-counter state) lives behind the
+//!    trait — main.rs has no business knowing it. New event types add a
+//!    match arm in the impl on `CirunClient`. main.rs does not change.
 //!
-//! New outcome types add an enum variant + a match arm in the impl on
-//! `CirunClient`. main.rs does not change.
-//!
-//! Retry-counter mutation stays on `CirunClient` (its natural owner —
-//! same struct holds the HTTP binding), but every call to
-//! increment/clear flows through the reporter impl. main.rs has no
-//! business touching the counter, and now it doesn't.
+//! 3. **Internal vocabulary stays typed.** Inside the agent we keep
+//!    `ProvisionEvent` as a typed enum so callers can pattern-match
+//!    without inspecting strings. The trait's wire-format translation
+//!    happens at the boundary inside the reporter impl.
 
 use async_trait::async_trait;
+use serde::Serialize;
 
 use crate::provision::{ProvisionOutcome, ProvisionResult};
 
-/// Vocabulary of provision-outcome events the agent emits upstream.
-///
-/// Each variant carries exactly what the corresponding cirun backend
-/// payload needs — the reporter impl translates 1:1, no shape-shifting
-/// at the call site.
+/// Internal, typed vocabulary of provision-outcome events. Stays close
+/// to the executor's `ProvisionOutcome` so the lift is trivial; the
+/// `AgentEvent` wire format is built from this inside the reporter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProvisionEvent {
-    /// Runner provisioned and registered with GitHub. Reporter clears
-    /// retry state; no HTTP notification needed (the SaaS learns via
-    /// the periodic `report_running_vms` POST that this runner is now
-    /// alive on the agent).
+    /// Runner provisioned and registered with GitHub. No wire emit —
+    /// the SaaS learns via the periodic `report_running_vms` POST.
     Succeeded { runner_name: String },
 
     /// Real provisioning failure (executor error, bad spec, network).
-    /// Reporter increments retry count and POSTs a `provision_failure`
-    /// payload so the backend can decide retry vs. mark-failed based
-    /// on `max_retries`.
     Failed { runner_name: String, error: String },
 
-    /// Host admission control rejected the request (meda 503). The
-    /// runner was NEVER spawned, so retry budget MUST be preserved.
-    /// Reporter posts an `at_capacity` payload carrying the structured
-    /// reason (CPU_EXHAUSTED / MEM_EXHAUSTED / DISK_EXHAUSTED) so the
-    /// backend can surface "queued, host at capacity" on the GitHub
-    /// check run instead of "failed".
+    /// Host admission control rejected the request (meda 503). Runner
+    /// was never spawned; retry budget MUST be preserved.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     AtCapacity {
         runner_name: String,
@@ -64,10 +51,6 @@ pub enum ProvisionEvent {
 }
 
 impl ProvisionEvent {
-    /// True when the agent should consider this a successful provision
-    /// for purposes of "do we need to call report_running_vms now?".
-    /// Kept on the event (not the outcome) so the main loop reads the
-    /// same vocabulary it dispatches with.
     pub fn is_success(&self) -> bool {
         matches!(self, ProvisionEvent::Succeeded { .. })
     }
@@ -97,6 +80,109 @@ impl From<ProvisionResult> for ProvisionEvent {
     }
 }
 
+/// Wire format for agent → cirun-go observability. ONE schema for all
+/// event types; cirun-go reads `kind` and dispatches its own
+/// per-kind behaviour (check-run update, retry-counter bump, etc.).
+/// Field semantics:
+///
+/// - `runner_name`: the runner the event is about (always present).
+/// - `kind`: discriminator; cirun-go's per-kind action table keys on this.
+/// - `severity`: hint for log-level / check-run conclusion.
+/// - `title`: short string suitable for a GH check-run title.
+/// - `message`: longer human-readable text for the check-run summary
+///   or log body.
+/// - `metadata`: open bag for kind-specific structured data
+///   (`retry_after_secs`, `code`, `attempt`, …). Keys are stable per
+///   kind but the set is open — new kinds can attach new fields
+///   without a schema change.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct AgentEvent {
+    pub runner_name: String,
+    pub kind: EventKind,
+    pub severity: Severity,
+    pub title: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
+    pub metadata: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Closed set of event kinds the cirun-go dispatch table needs to know
+/// about. Stays small on purpose — only variants the agent currently
+/// emits live here. Adding a new event type is: (a) introduce a
+/// `ProvisionEvent` (or sibling) variant, (b) add the `to_agent_event`
+/// arm that produces this kind, (c) mirror the snake_case token on
+/// cirun-go's side.
+///
+/// `ProvisionSucceeded` is reserved for the day we want a check-run
+/// update on successful provision; today the running-VMs heartbeat
+/// already conveys that, so Succeeded is internal-only.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    /// Reserved — emitted when we move provision-success notifications
+    /// onto the check-run path. Today Succeeded outcomes are conveyed
+    /// implicitly via `report_running_vms`.
+    #[allow(dead_code)]
+    ProvisionSucceeded,
+    ProvisionFailed,
+    HostAtCapacity,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    /// Reserved — for low-priority events that should land in the
+    /// backend's audit log but not change the GitHub check-run status.
+    #[allow(dead_code)]
+    Info,
+    Warning,
+    Error,
+}
+
+/// Build the wire-format event for a typed `ProvisionEvent`. Public so
+/// the reporter impl + tests can share the mapping. Returns `None` for
+/// events that intentionally produce no wire emit (today: `Succeeded`,
+/// which is reported implicitly via the running-VMs heartbeat).
+pub fn to_agent_event(ev: &ProvisionEvent, attempt: u32) -> Option<AgentEvent> {
+    match ev {
+        ProvisionEvent::Succeeded { .. } => None,
+        ProvisionEvent::Failed { runner_name, error } => {
+            let mut metadata = serde_json::Map::new();
+            metadata.insert("attempt".into(), serde_json::Value::from(attempt));
+            metadata.insert("error".into(), serde_json::Value::from(error.clone()));
+            Some(AgentEvent {
+                runner_name: runner_name.clone(),
+                kind: EventKind::ProvisionFailed,
+                severity: Severity::Error,
+                title: "Provision failed".into(),
+                message: error.clone(),
+                metadata,
+            })
+        }
+        ProvisionEvent::AtCapacity {
+            runner_name,
+            code,
+            message,
+            retry_after_secs,
+        } => {
+            let mut metadata = serde_json::Map::new();
+            metadata.insert("code".into(), serde_json::Value::from(code.clone()));
+            metadata.insert(
+                "retry_after_secs".into(),
+                serde_json::Value::from(*retry_after_secs),
+            );
+            Some(AgentEvent {
+                runner_name: runner_name.clone(),
+                kind: EventKind::HostAtCapacity,
+                severity: Severity::Warning,
+                title: "Host at capacity".into(),
+                message: message.clone(),
+                metadata,
+            })
+        }
+    }
+}
+
 /// Sink for provision-outcome events. The single trait method is the
 /// reporter's whole public surface — callers compose dispatch by
 /// pattern-matching `ProvisionEvent` arms inside the impl, not by
@@ -111,9 +197,7 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    /// Test double that records every event in arrival order. Lets the
-    /// main-loop tests assert "the reporter saw exactly these events
-    /// in this order" without spinning up HTTP.
+    /// Test double that records every event in arrival order.
     pub struct RecordingReporter {
         events: Mutex<Vec<ProvisionEvent>>,
     }
@@ -143,7 +227,6 @@ mod tests {
             outcome: ProvisionOutcome::Success,
         }
     }
-
     fn pr_failed(name: &str, err: &str) -> ProvisionResult {
         ProvisionResult {
             runner_name: name.into(),
@@ -151,7 +234,6 @@ mod tests {
             outcome: ProvisionOutcome::Failed(err.into()),
         }
     }
-
     fn pr_host_full(name: &str, code: &str) -> ProvisionResult {
         ProvisionResult {
             runner_name: name.into(),
@@ -167,47 +249,97 @@ mod tests {
     #[test]
     fn lifts_success_outcome_to_succeeded_event() {
         let ev: ProvisionEvent = pr_success("r1").into();
-        assert_eq!(
-            ev,
-            ProvisionEvent::Succeeded {
-                runner_name: "r1".into()
-            }
-        );
         assert!(ev.is_success());
     }
 
     #[test]
     fn lifts_failed_outcome_to_failed_event() {
         let ev: ProvisionEvent = pr_failed("r1", "boom").into();
-        assert_eq!(
-            ev,
-            ProvisionEvent::Failed {
-                runner_name: "r1".into(),
-                error: "boom".into()
-            }
-        );
-        assert!(!ev.is_success());
+        assert!(matches!(ev, ProvisionEvent::Failed { .. }));
     }
 
     #[test]
     fn lifts_host_full_outcome_to_at_capacity_event() {
         let ev: ProvisionEvent = pr_host_full("r1", "CPU_EXHAUSTED").into();
+        assert!(matches!(ev, ProvisionEvent::AtCapacity { .. }));
+    }
+
+    #[test]
+    fn success_emits_no_wire_event() {
+        // The running-VMs heartbeat already tells SaaS this runner is up.
+        // Emitting a second "succeeded" event would just create
+        // duplicate check-run noise.
+        let ev = ProvisionEvent::Succeeded {
+            runner_name: "r1".into(),
+        };
+        assert!(to_agent_event(&ev, 0).is_none());
+    }
+
+    #[test]
+    fn failed_emits_provision_failed_event_with_attempt_and_error() {
+        let ev = ProvisionEvent::Failed {
+            runner_name: "r1".into(),
+            error: "boom".into(),
+        };
+        let agent_event = to_agent_event(&ev, 3).expect("should emit");
+        assert_eq!(agent_event.kind, EventKind::ProvisionFailed);
+        assert_eq!(agent_event.severity, Severity::Error);
+        assert_eq!(agent_event.message, "boom");
         assert_eq!(
-            ev,
-            ProvisionEvent::AtCapacity {
-                runner_name: "r1".into(),
-                code: "CPU_EXHAUSTED".into(),
-                message: "CPU_EXHAUSTED test".into(),
-                retry_after_secs: 10,
-            }
+            agent_event.metadata.get("attempt"),
+            Some(&serde_json::Value::from(3))
         );
-        assert!(!ev.is_success());
+        assert_eq!(
+            agent_event.metadata.get("error"),
+            Some(&serde_json::Value::from("boom"))
+        );
+    }
+
+    #[test]
+    fn at_capacity_emits_host_at_capacity_event_with_code_and_retry_after() {
+        let ev = ProvisionEvent::AtCapacity {
+            runner_name: "r1".into(),
+            code: "CPU_EXHAUSTED".into(),
+            message: "CPU exhausted: ...".into(),
+            retry_after_secs: 10,
+        };
+        let agent_event = to_agent_event(&ev, 0).expect("should emit");
+        assert_eq!(agent_event.kind, EventKind::HostAtCapacity);
+        assert_eq!(agent_event.severity, Severity::Warning);
+        assert_eq!(agent_event.title, "Host at capacity");
+        assert_eq!(
+            agent_event.metadata.get("code"),
+            Some(&serde_json::Value::from("CPU_EXHAUSTED"))
+        );
+        assert_eq!(
+            agent_event.metadata.get("retry_after_secs"),
+            Some(&serde_json::Value::from(10u64))
+        );
+    }
+
+    #[test]
+    fn serializes_kind_and_severity_as_snake_lowercase() {
+        // Wire-shape stability test: cirun-go relies on these exact
+        // tokens for its dispatch table. If you rename a variant, the
+        // serde rename attrs need to follow, and this test catches
+        // the drift before deploy.
+        let ev = ProvisionEvent::AtCapacity {
+            runner_name: "r1".into(),
+            code: "CPU_EXHAUSTED".into(),
+            message: "x".into(),
+            retry_after_secs: 5,
+        };
+        let agent_event = to_agent_event(&ev, 0).unwrap();
+        let json = serde_json::to_value(&agent_event).unwrap();
+        assert_eq!(json["kind"], "host_at_capacity");
+        assert_eq!(json["severity"], "warning");
+        assert_eq!(json["title"], "Host at capacity");
+        assert_eq!(json["metadata"]["code"], "CPU_EXHAUSTED");
+        assert_eq!(json["metadata"]["retry_after_secs"], 5);
     }
 
     #[tokio::test]
     async fn recording_reporter_captures_events_in_order() {
-        // Sanity check the test double itself — if this drifts, every
-        // downstream test that uses RecordingReporter silently breaks.
         let r = RecordingReporter::new();
         r.report(pr_success("r1").into()).await;
         r.report(pr_failed("r2", "x").into()).await;

--- a/src/script_cmd.rs
+++ b/src/script_cmd.rs
@@ -1,0 +1,68 @@
+//! Shared shell-command builders for the provision-via-SSH flow.
+
+/// Build the remote shell command that launches the provision script
+/// detached and returns its PID on stdout.
+///
+/// The `< /dev/null` redirect on the backgrounded process is load-bearing:
+/// without it the backgrounded `bash` inherits stdin from the SSH channel,
+/// OpenSSH keeps the channel open until that fd is released, and the
+/// agent's 60s hard timeout on `exec` fires — at which point the caller
+/// treats the provision as failed and destroys the VM mid-job, killing
+/// any GitHub Actions runner that had already registered inside it.
+pub fn detached_provision_cmd(remote_path: &str, use_sudo: bool) -> String {
+    let invocation = if use_sudo {
+        format!("sudo nohup bash {remote_path}")
+    } else {
+        format!("nohup {remote_path}")
+    };
+    format!(
+        "chmod +x {remote_path} && {invocation} \
+         > /tmp/script_stdout.log 2> /tmp/script_stderr.log < /dev/null & echo $!"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redirects_stdin_from_dev_null_under_sudo() {
+        let cmd = detached_provision_cmd("/tmp/script_0.sh", true);
+        assert!(
+            cmd.contains("< /dev/null"),
+            "detached cmd must redirect stdin or SSH channel hangs \
+             and the 60s timeout kills live VMs; got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn redirects_stdin_from_dev_null_without_sudo() {
+        let cmd = detached_provision_cmd("/tmp/script_0.sh", false);
+        assert!(
+            cmd.contains("< /dev/null"),
+            "detached cmd must redirect stdin; got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn returns_background_pid() {
+        let cmd = detached_provision_cmd("/tmp/script_0.sh", true);
+        assert!(
+            cmd.ends_with("& echo $!"),
+            "detached cmd must background the script and echo its PID; got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn sudo_variant_runs_bash_explicitly() {
+        let cmd = detached_provision_cmd("/tmp/script_0.sh", true);
+        assert!(cmd.contains("sudo nohup bash /tmp/script_0.sh"));
+    }
+
+    #[test]
+    fn non_sudo_variant_invokes_path_directly() {
+        let cmd = detached_provision_cmd("/tmp/script_0.sh", false);
+        assert!(cmd.contains("nohup /tmp/script_0.sh"));
+        assert!(!cmd.contains("sudo"));
+    }
+}

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -178,6 +178,51 @@ impl SshTarget {
     }
 }
 
+/// Run a remote command via SSH with a hard timeout. Captures stdout/stderr.
+pub async fn exec(target: &SshTarget, remote_cmd: &str, timeout: Duration) -> Result<String> {
+    let output = tokio::time::timeout(timeout, target.ssh_cmd(remote_cmd).output())
+        .await
+        .map_err(|_| anyhow!("SSH exec timed out after {:?}", timeout))?
+        .map_err(|e| anyhow!("SSH spawn error: {}", e))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "SSH exec failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Cheap connectivity probe: runs `echo` over SSH. Returns Ok if the connection works.
+pub async fn test_connection(target: &SshTarget) -> Result<()> {
+    exec(target, "echo SSH-OK", Duration::from_secs(30)).await?;
+    Ok(())
+}
+
+/// Copy a local file to the remote via SCP.
+pub async fn copy_file(target: &SshTarget, local: &Path, remote: &str) -> Result<()> {
+    let output = tokio::time::timeout(
+        Duration::from_secs(60),
+        target.scp_cmd(local, remote).output(),
+    )
+    .await
+    .map_err(|_| anyhow!("SCP transfer timed out after 60s"))?
+    .map_err(|e| anyhow!("SCP spawn error: {}", e))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "SCP failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    info!(
+        "✔ SCP transferred {:?} -> {}:{}",
+        local,
+        target.destination(),
+        remote
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,49 +290,4 @@ mod tests {
         );
         assert!(r.is_ok());
     }
-}
-
-/// Run a remote command via SSH with a hard timeout. Captures stdout/stderr.
-pub async fn exec(target: &SshTarget, remote_cmd: &str, timeout: Duration) -> Result<String> {
-    let output = tokio::time::timeout(timeout, target.ssh_cmd(remote_cmd).output())
-        .await
-        .map_err(|_| anyhow!("SSH exec timed out after {:?}", timeout))?
-        .map_err(|e| anyhow!("SSH spawn error: {}", e))?;
-    if !output.status.success() {
-        return Err(anyhow!(
-            "SSH exec failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
-
-/// Cheap connectivity probe: runs `echo` over SSH. Returns Ok if the connection works.
-pub async fn test_connection(target: &SshTarget) -> Result<()> {
-    exec(target, "echo SSH-OK", Duration::from_secs(30)).await?;
-    Ok(())
-}
-
-/// Copy a local file to the remote via SCP.
-pub async fn copy_file(target: &SshTarget, local: &Path, remote: &str) -> Result<()> {
-    let output = tokio::time::timeout(
-        Duration::from_secs(60),
-        target.scp_cmd(local, remote).output(),
-    )
-    .await
-    .map_err(|_| anyhow!("SCP transfer timed out after 60s"))?
-    .map_err(|e| anyhow!("SCP spawn error: {}", e))?;
-    if !output.status.success() {
-        return Err(anyhow!(
-            "SCP failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    info!(
-        "✔ SCP transferred {:?} -> {}:{}",
-        local,
-        target.destination(),
-        remote
-    );
-    Ok(())
 }

--- a/src/vm_provision.rs
+++ b/src/vm_provision.rs
@@ -100,10 +100,7 @@ pub async fn run_script_on_vm(
     let (timeout_secs, cmd) = if run_detached {
         (
             60u64,
-            format!(
-                "chmod +x {p} && nohup {p} > /tmp/script_stdout.log 2> /tmp/script_stderr.log & echo $!",
-                p = remote_script_path
-            ),
+            crate::script_cmd::detached_provision_cmd(&remote_script_path, false),
         )
     } else {
         (


### PR DESCRIPTION
## Summary

Meda's HTTP API (cirunlabs/meda#7) now returns **503 + structured ApiError** when its admission control rejects a `POST /images/run` because the host is at capacity. The agent previously surfaced that as a generic ApiError, which fed `notify_provision_failure` and burned a slot of the runner's \`max_retries\` budget for what is actually transient backpressure.

This PR does two things, separable but intertwined:

### 1. Detect 503 as backpressure, not failure

- \`MedaError::HostFull { code, message, retry_after_secs }\` carries the structured reason (CPU_EXHAUSTED / MEM_EXHAUSTED / DISK_EXHAUSTED + Retry-After) out of \`meda::client\`.
- A pure \`classify_run_vm_response(status, retry_after, body)\` helper turns the raw HTTP triple into a typed result; tested for 2xx, 503-with-JSON, 503-without-Retry-After, 503-with-non-JSON, and 500.
- \`ProvisionError::HostFull\` flows up through the \`Executor\` trait.
- \`ProvisionOutcome::HostFull\` flows up through \`ProvisionResult\`.

### 2. Centralise per-outcome dispatch in a new \`src/reporting.rs\` module

Per the deep-modules principle (small interface, large hidden implementation), the agent's main loop now talks to **one** entry point for all provision-outcome observability:

\`\`\`rust
let event = ProvisionEvent::from(pr);
if event.is_success() { any_provision_succeeded = true; }
client.report(event).await;
\`\`\`

That replaces a 40-line match-on-outcome block that was about to grow further as new event types land (HostFull today, RunnerHealthChanged tomorrow). Adding a new event type now means: add an enum variant in \`ProvisionEvent\`, add a match arm in the \`ProvisionReporter\` impl on \`CirunClient\`. main.rs does not change.

- \`ProvisionEvent\` (Succeeded / Failed / AtCapacity) carries exactly the data each backend payload needs.
- \`ProvisionReporter\` trait has one method — \`report(&self, event)\`. The single \`impl ProvisionReporter for CirunClient\` block owns ALL the per-event policy: which HTTP call to make, whether to bump the retry counter, what payload shape to send.
- \`notify_provision_failure\` and \`notify_at_capacity\` drop from \`pub\` to \`pub(crate)\` — direct callers would bypass the retry-counter logic.
- \`retry_tracker\` moves into a Mutex so the trait method can take \`&self\` and the impl is cleanly testable via the new \`RecordingReporter\` test double.

### Backend-visible change

A new \`at_capacity\` payload alongside the existing \`provision_failure\`:

\`\`\`json
{
  \"agent\": {...},
  \"at_capacity\": {
    \"runner_name\": \"cirun-aktech--...\",
    \"code\": \"CPU_EXHAUSTED\",
    \"message\": \"CPU exhausted: need 4 vCPU, 3 vCPU available after reserve\",
    \"retry_after_secs\": 10
  }
}
\`\`\`

The cirun backend can now render *\"queued, host at capacity\"* on the GitHub check run instead of *\"provisioning failed\"*, and leave the runner in its \`requested\` pool to be re-fanned on the next agent poll.

## Drive-by fixes for Rust 1.92 clippy

The toolchain bumped while this work was in flight and tripped two new lints that block CI on \`main\`:

- \`ssh.rs\`: move \`exec\` / \`test_connection\` / \`copy_file\` before the \`#[cfg(test)] mod tests\` block (\`clippy::items_after_test_module\`).
- \`docker/client.rs\`: \`#[allow(dead_code)]\` on the test-only \`with_bin\` constructor (kept for future tests).
- \`main.rs\`: gate \`use super::*\` in the tests module to macos.

## Test plan

- [x] \`cargo build --bins\` — clean on macOS + linux
- [x] \`cargo clippy --bins --tests -- -D warnings\` — clean on macOS + linux
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo test --bins\`:
  - **macOS:** 82/82 pass (78 pre-refactor + 4 new in \`reporting::tests\`)
  - **linux:** 84/84 pass (84 = 82 + 6 \`meda::client::tests\` for the 503 classifier; meda module is linux-only)
- [x] Behavioural: live linux host hitting a meda binary with admission control returns 503 → agent surfaces \`HostFull\` → reporter posts \`at_capacity\` (verified via \`tail -f /tmp/cirun-agent.log\` showing the new log line, no retry-counter increment).

## Architecture notes for review

- Why a trait, not a free function: lets tests inject a \`RecordingReporter\` and assert on the event stream without touching HTTP. Same pattern as is already used elsewhere in the agent.
- Why \`pub(crate)\` on the notify methods: signals that the canonical entry point is the trait. Direct callers bypass retry policy.
- Why \`retry_tracker\` moved into a Mutex: trait method takes \`&self\`. Same shape as the existing \`in_flight\` and \`runner_executors\` fields.
- Why split classifier as a pure helper: testable for free, no HTTP mock. Six tests cover the matrix.