### PR TITLE
fix(provision): kill SSH after PID read + ship structured diagnostics

### DIFF
--- a/src/cirun_client.rs
+++ b/src/cirun_client.rs
@@ -400,6 +400,7 @@ impl CirunClient {
                     self.report(crate::reporting::ProvisionEvent::Failed {
                         runner_name: runner.name.clone(),
                         error: format!("Exceeded max retries ({})", runner.max_retries),
+                        diagnostics: serde_json::Map::new(),
                     })
                     .await;
                 }

--- a/src/executor/docker.rs
+++ b/src/executor/docker.rs
@@ -127,13 +127,13 @@ impl Executor for DockerExecutor {
                 name,
             ])
             .output()
-            .map_err(|e| ProvisionError::Transient(format!("docker inspect: {e}")))?;
+            .map_err(|e| ProvisionError::transient(format!("docker inspect: {e}")))?;
         if !out.status.success() {
             let stderr = String::from_utf8_lossy(&out.stderr);
             if is_docker_not_found(&stderr) {
                 return Ok(RunnerState::Absent);
             }
-            return Err(ProvisionError::Transient(format!(
+            return Err(ProvisionError::transient(format!(
                 "docker inspect failed: {}",
                 stderr
             )));
@@ -195,20 +195,20 @@ impl Executor for DockerExecutor {
         self.client
             .run_runner(&container_spec)
             .map(|_| ())
-            .map_err(|e| ProvisionError::Transient(format!("docker run failed: {e}")))
+            .map_err(|e| ProvisionError::transient(format!("docker run failed: {e}")))
     }
 
     async fn kill(&self, name: &str) -> Result<(), ProvisionError> {
         self.client
             .stop_and_remove(name)
-            .map_err(|e| ProvisionError::Transient(format!("docker rm: {e}")))
+            .map_err(|e| ProvisionError::transient(format!("docker rm: {e}")))
     }
 
     async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError> {
         let infos = self
             .client
             .list_runner_containers("cirun.runner=true")
-            .map_err(|e| ProvisionError::Transient(format!("docker ps: {e}")))?;
+            .map_err(|e| ProvisionError::transient(format!("docker ps: {e}")))?;
         Ok(infos
             .into_iter()
             .map(|i| OwnedRunner {

--- a/src/executor/lume.rs
+++ b/src/executor/lume.rs
@@ -33,7 +33,7 @@ pub struct LumeExecutor {
 impl LumeExecutor {
     pub fn new() -> Result<Self, ProvisionError> {
         let client = crate::lume::client::LumeClient::new()
-            .map_err(|e| ProvisionError::Transient(format!("lume init: {e}")))?;
+            .map_err(|e| ProvisionError::transient(format!("lume init: {e}")))?;
         Ok(Self {
             client: Arc::new(client),
         })
@@ -74,7 +74,7 @@ impl Executor for LumeExecutor {
         self.client
             .clone_vm(&spec.image, &spec.name)
             .await
-            .map_err(|e| ProvisionError::Transient(format!("lume clone_vm: {e:?}")))?;
+            .map_err(|e| ProvisionError::transient(format!("lume clone_vm: {e:?}")))?;
         let run_config = RunConfig {
             no_display: Some(true),
             shared_directories: None,
@@ -83,7 +83,7 @@ impl Executor for LumeExecutor {
         self.client
             .run_vm(&spec.name, Some(run_config))
             .await
-            .map_err(|e| ProvisionError::Transient(format!("lume run_vm: {e:?}")))?;
+            .map_err(|e| ProvisionError::transient(format!("lume run_vm: {e:?}")))?;
         // Block until the daemon shows the VM has left `stopped`. The xcode
         // image is larger and slower to start than vanilla — 30s wasn't
         // enough on m1 (observed 2026-05-15). 120s is generous; actual boot
@@ -97,7 +97,7 @@ impl Executor for LumeExecutor {
                 Err(e) => log::debug!("lume get_vm during spawn-wait: {e:?}"),
             }
             if tokio::time::Instant::now() >= deadline {
-                return Err(ProvisionError::Transient(format!(
+                return Err(ProvisionError::transient(format!(
                     "lume VM '{}' did not leave 'stopped' state within 120s of run_vm",
                     spec.name
                 )));
@@ -109,7 +109,7 @@ impl Executor for LumeExecutor {
         self.client
             .delete_vm(name)
             .await
-            .map_err(|e| ProvisionError::Transient(format!("lume delete_vm: {e:?}")))
+            .map_err(|e| ProvisionError::transient(format!("lume delete_vm: {e:?}")))
     }
 
     async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError> {
@@ -117,7 +117,7 @@ impl Executor for LumeExecutor {
             .client
             .list_vms()
             .await
-            .map_err(|e| ProvisionError::Transient(format!("lume list_vms: {e:?}")))?;
+            .map_err(|e| ProvisionError::transient(format!("lume list_vms: {e:?}")))?;
         Ok(vms
             .into_iter()
             .filter(|v| v.name.starts_with("cirun-"))
@@ -142,7 +142,7 @@ impl Executor for LumeExecutor {
         )
         .await
         .map(|_| ())
-        .map_err(|e| ProvisionError::Transient(format!("provision script: {e}")))
+        .map_err(|e| ProvisionError::transient(format!("provision script: {e}")))
     }
 }
 

--- a/src/executor/meda.rs
+++ b/src/executor/meda.rs
@@ -1,6 +1,6 @@
 //! Meda adapter: wraps `crate::meda::client::MedaClient` behind the `Executor` trait.
 
-use super::{Executor, OwnedRunner, ProvisionError, RunnerLogin, RunnerSpec, RunnerState};
+use super::{Executor, OwnedRunner, ProvisionError, RunnerSpec, RunnerState};
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,7 +28,7 @@ pub struct MedaExecutor {
 impl MedaExecutor {
     pub fn new() -> Result<Self, ProvisionError> {
         let client = crate::meda::client::MedaClient::new()
-            .map_err(|e| ProvisionError::Transient(format!("meda init: {e}")))?;
+            .map_err(|e| ProvisionError::transient(format!("meda init: {e}")))?;
         Ok(Self {
             client: Arc::new(client),
         })
@@ -72,7 +72,7 @@ impl Executor for MedaExecutor {
                 message,
                 retry_after_secs,
             }),
-            Err(e) => Err(ProvisionError::Transient(format!("meda run_vm: {e:?}"))),
+            Err(e) => Err(ProvisionError::transient(format!("meda run_vm: {e:?}"))),
         }
     }
 
@@ -80,7 +80,7 @@ impl Executor for MedaExecutor {
         self.client
             .delete_vm(name)
             .await
-            .map_err(|e| ProvisionError::Transient(format!("meda delete_vm: {e:?}")))
+            .map_err(|e| ProvisionError::transient(format!("meda delete_vm: {e:?}")))
     }
 
     async fn list_owned(&self) -> Result<Vec<OwnedRunner>, ProvisionError> {
@@ -88,7 +88,7 @@ impl Executor for MedaExecutor {
             .client
             .list_vms()
             .await
-            .map_err(|e| ProvisionError::Transient(format!("meda list_vms: {e:?}")))?;
+            .map_err(|e| ProvisionError::transient(format!("meda list_vms: {e:?}")))?;
         Ok(vms
             .into_iter()
             .filter(|v| v.name.starts_with("cirun-"))
@@ -100,104 +100,49 @@ impl Executor for MedaExecutor {
     }
 
     /// After meda reports the VM "running", we still need to wait for DHCP +
-    /// SSH before the provision script can be pushed. That belongs here, not
-    /// in the trait's settle loop.
+    /// SSH before the provision script can be pushed. The actual
+    /// push-script + run-detached + diagnostic-capture lifecycle lives
+    /// in `crate::provision_push` so every SSH-based executor shares
+    /// the same kill-after-PID-read fix and the same structured
+    /// observability bag.
     async fn run_post_spawn(&self, spec: &RunnerSpec) -> Result<(), ProvisionError> {
+        use crate::ssh::{SshAuth, SshTarget};
         log::info!("Waiting for VM '{}' to get an IP address...", spec.name);
         let ip = self
             .client
             .wait_for_vm_ip(&spec.name, 300)
             .await
-            .map_err(|e| ProvisionError::Transient(format!("wait_for_vm_ip: {e:?}")))?;
+            .map_err(|e| ProvisionError::transient(format!("wait_for_vm_ip: {e:?}")))?;
         log::info!("VM '{}' has IP {}; pushing provision script", spec.name, ip);
 
-        push_provision_script_via_ssh(&spec.name, &ip, &spec.provision_script, &spec.login, true)
+        let home_dir = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+        let target = SshTarget::new(
+            ip.clone(),
+            spec.login.username.clone(),
+            SshAuth::Key(std::path::PathBuf::from(format!(
+                "{home_dir}/.meda/ssh/id_ed25519"
+            ))),
+        )
+        .map_err(|e| ProvisionError::transient(format!("ssh target: {e}")))?;
+
+        let ctx = crate::provision_push::PushContext {
+            vm_name: &spec.name,
+            vm_ip: &ip,
+            target,
+            script: &spec.provision_script,
+            use_sudo: true,
+            detached_exec_timeout: Duration::from_secs(60),
+        };
+        crate::provision_push::push_and_run_detached(&ctx)
             .await
-            .map(|_| ())
-            .map_err(|e| ProvisionError::Transient(format!("provision script: {e}")))
+            .map(|_pid| ())
+            .map_err(|f| {
+                ProvisionError::transient_with(
+                    format!("provision script: {}", f.message),
+                    f.diagnostics,
+                )
+            })
     }
-}
-
-/// SSH the meda VM with its ed25519 key, scp the provision script, run it
-/// under `sudo bash`. Detached mode launches in background (short timeout);
-/// blocking mode waits up to 10 minutes for completion. Lives next to the
-/// `MedaExecutor` that owns the SSH-push lifecycle.
-async fn push_provision_script_via_ssh(
-    vm_name: &str,
-    ip_address: &str,
-    script_content: &str,
-    login: &RunnerLogin,
-    run_detached: bool,
-) -> Result<String, Box<dyn std::error::Error>> {
-    use crate::ssh::{copy_file, exec, test_connection, SshAuth, SshTarget};
-    use std::io::Write;
-    use std::time::Instant;
-    use tempfile::NamedTempFile;
-
-    log::info!("VM '{}' is ready with IP: {}", vm_name, ip_address);
-
-    let mut temp_file = NamedTempFile::new()?;
-    temp_file.write_all(script_content.as_bytes())?;
-
-    let home_dir = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    let target = SshTarget::new(
-        ip_address.to_string(),
-        login.username.clone(),
-        SshAuth::Key(std::path::PathBuf::from(format!(
-            "{}/.meda/ssh/id_ed25519",
-            home_dir
-        ))),
-    )?;
-
-    // Wait for SSH to be ready (VM may still be booting).
-    let max_retries = 6usize;
-    let mut last_err: Option<String> = None;
-    for attempt in 1..=max_retries {
-        match test_connection(&target).await {
-            Ok(()) => {
-                log::info!("✔ SSH ready (attempt {}/{})", attempt, max_retries);
-                last_err = None;
-                break;
-            }
-            Err(e) => {
-                last_err = Some(e.to_string());
-                if attempt < max_retries {
-                    log::info!("SSH not ready (attempt {}/{}): {}", attempt, max_retries, e);
-                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                }
-            }
-        }
-    }
-    if let Some(e) = last_err {
-        return Err(format!("SSH not reachable after {max_retries} retries: {e}").into());
-    }
-
-    let remote_path = format!("/tmp/script_{}.sh", Instant::now().elapsed().as_secs());
-    copy_file(&target, temp_file.path(), &remote_path)
-        .await
-        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-
-    // meda scripts run with sudo. Detached: short launch timeout. Blocking: 10min.
-    let (timeout_secs, cmd) = if run_detached {
-        (
-            60u64,
-            crate::script_cmd::detached_provision_cmd(&remote_path, true),
-        )
-    } else {
-        (
-            600u64,
-            format!("chmod +x {p} && sudo bash {p}", p = remote_path),
-        )
-    };
-    let stdout = exec(
-        &target,
-        &cmd,
-        tokio::time::Duration::from_secs(timeout_secs),
-    )
-    .await
-    .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    log::info!("Script execution completed successfully.");
-    Ok(stdout)
 }
 
 #[cfg(test)]

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -156,9 +156,15 @@ pub struct OwnedRunner {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProvisionError {
-    /// Caller may retry.
-    #[error("transient: {0}")]
-    Transient(String),
+    /// Caller may retry. `diagnostics` is an open-ended JSON bag that
+    /// rides up the chain and lands in the `AgentEvent.metadata` cirun-go
+    /// receives — use it for structured root-cause hints (elapsed_ms,
+    /// partial SSH stdio, VM-side state captures).
+    #[error("transient: {message}")]
+    Transient {
+        message: String,
+        diagnostics: serde_json::Map<String, serde_json::Value>,
+    },
     /// Permanent runtime failure — do not retry. Constructed by the lume
     /// executor (macos-only); kept on linux for parity with the trait
     /// surface so callers can match exhaustively without cfg branches.
@@ -181,6 +187,33 @@ pub enum ProvisionError {
         message: String,
         retry_after_secs: u64,
     },
+}
+
+impl ProvisionError {
+    /// Build a transient error with no structured diagnostics — the
+    /// common case for callers that only have a human message. Use
+    /// `transient_with` when you've already gathered a metadata bag.
+    pub fn transient(msg: impl Into<String>) -> Self {
+        Self::Transient {
+            message: msg.into(),
+            diagnostics: serde_json::Map::new(),
+        }
+    }
+
+    /// Build a transient error with a structured diagnostics bag.
+    /// Meda's detached-exec failure path uses this to attach the SSH
+    /// timing + VM-side state capture so the cirun-go event log carries
+    /// enough context to root-cause the failure without an SSH shell.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn transient_with(
+        msg: impl Into<String>,
+        diagnostics: serde_json::Map<String, serde_json::Value>,
+    ) -> Self {
+        Self::Transient {
+            message: msg.into(),
+            diagnostics,
+        }
+    }
 }
 
 #[async_trait]
@@ -242,7 +275,7 @@ pub trait Executor: Send + Sync {
                 RunnerState::Starting => {
                     if tokio::time::Instant::now() >= deadline {
                         let _ = self.kill(&spec.name).await;
-                        return Err(ProvisionError::Transient(format!(
+                        return Err(ProvisionError::transient(format!(
                             "runner '{}' did not reach Healthy within {:?}",
                             spec.name,
                             self.settle_timeout()
@@ -254,13 +287,13 @@ pub trait Executor: Send + Sync {
                     last_logs,
                 } => {
                     let _ = self.kill(&spec.name).await;
-                    return Err(ProvisionError::Transient(format!(
+                    return Err(ProvisionError::transient(format!(
                         "runner '{}' exited (code={:?}) during settle: {}",
                         spec.name, exit_code, last_logs
                     )));
                 }
                 RunnerState::Absent => {
-                    return Err(ProvisionError::Transient(format!(
+                    return Err(ProvisionError::transient(format!(
                         "runner '{}' disappeared during settle",
                         spec.name
                     )));

--- a/src/executor/tests.rs
+++ b/src/executor/tests.rs
@@ -325,7 +325,7 @@ async fn provision_returns_transient_on_settle_timeout() {
     exec.settle_interval = Duration::from_millis(3);
     let err = exec.provision(&spec("r1")).await.unwrap_err();
     assert!(
-        matches!(err, ProvisionError::Transient(_)),
+        matches!(err, ProvisionError::Transient { .. }),
         "expected Transient, got {:?}",
         err
     );
@@ -347,7 +347,7 @@ async fn provision_returns_transient_when_terminated_during_settle() {
     ]);
     let err = exec.provision(&spec("r1")).await.unwrap_err();
     assert!(
-        matches!(err, ProvisionError::Transient(_)),
+        matches!(err, ProvisionError::Transient { .. }),
         "expected Transient, got {:?}",
         err
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod lume;
 #[cfg(target_os = "linux")]
 mod meda;
 mod provision;
+mod provision_push;
 mod reporting;
 mod script_cmd;
 mod service;

--- a/src/provision.rs
+++ b/src/provision.rs
@@ -31,13 +31,33 @@ use tokio::sync::Semaphore;
 ///   host at capacity" on the GitHub check run instead of "failed".
 pub enum ProvisionOutcome {
     Success,
-    Failed(String),
+    /// Real provisioning failure. `diagnostics` is an open-ended bag —
+    /// most call sites have nothing structured to attach (empty map),
+    /// but the meda detached-exec failure path stuffs SSH timing +
+    /// VM-side state captures here so the upstream `AgentEvent` can
+    /// carry them to cirun-go.
+    Failed {
+        error: String,
+        diagnostics: serde_json::Map<String, serde_json::Value>,
+    },
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     HostFull {
         code: String,
         message: String,
         retry_after_secs: u64,
     },
+}
+
+impl ProvisionOutcome {
+    /// Build a `Failed` outcome with no structured diagnostics. Sites
+    /// that want to attach a metadata bag construct the variant
+    /// directly with `ProvisionOutcome::Failed { error, diagnostics }`.
+    pub fn failed(msg: impl Into<String>) -> Self {
+        Self::Failed {
+            error: msg.into(),
+            diagnostics: serde_json::Map::new(),
+        }
+    }
 }
 
 /// Result of a single runner provisioning attempt
@@ -109,7 +129,7 @@ pub async fn provision_single_runner(
             return ProvisionResult {
                 runner_name: runner.name.clone(),
                 executor_kind: None,
-                outcome: ProvisionOutcome::Failed(format!("Cannot derive executor: {e}")),
+                outcome: ProvisionOutcome::failed(format!("Cannot derive executor: {e}")),
             };
         }
     };
@@ -155,7 +175,7 @@ pub async fn provision_single_runner(
                             return ProvisionResult {
                                 runner_name: runner.name.clone(),
                                 executor_kind: Some(executor_kind),
-                                outcome: ProvisionOutcome::Failed(format!(
+                                outcome: ProvisionOutcome::failed(format!(
                                     "Template creation failed: {}",
                                     e
                                 )),
@@ -184,7 +204,7 @@ pub async fn provision_single_runner(
             return ProvisionResult {
                 runner_name: runner.name.clone(),
                 executor_kind: Some(executor_kind),
-                outcome: ProvisionOutcome::Failed("No template available".to_string()),
+                outcome: ProvisionOutcome::failed("No template available".to_string()),
             };
         }
     };
@@ -218,7 +238,7 @@ pub async fn provision_single_runner(
             return ProvisionResult {
                 runner_name: runner.name.clone(),
                 executor_kind: Some(executor_kind),
-                outcome: ProvisionOutcome::Failed(format!("Invalid gpu request: {e}")),
+                outcome: ProvisionOutcome::failed(format!("Invalid gpu request: {e}")),
             };
         }
     };
@@ -274,7 +294,7 @@ pub async fn provision_single_runner(
                     "Failed to provision runner {} using template {}: {}",
                     runner.name, template_name, error_msg
                 );
-                ProvisionOutcome::Failed(error_msg)
+                ProvisionOutcome::failed(error_msg)
             }
         },
         Err(e) => {
@@ -283,7 +303,7 @@ pub async fn provision_single_runner(
                 "Failed to provision runner {} (registry lookup): {}",
                 runner.name, error_msg
             );
-            ProvisionOutcome::Failed(error_msg)
+            ProvisionOutcome::failed(error_msg)
         }
     };
 

--- a/src/provision_push.rs
+++ b/src/provision_push.rs
@@ -1,0 +1,235 @@
+//! Shared post-spawn lifecycle for SSH-based executors (meda, lume).
+//!
+//! Every SSH-based executor needs the same sequence after the VM is up:
+//!
+//!   1. wait for SSH (with retries),
+//!   2. SCP the provision script onto the VM,
+//!   3. run it detached and read the PID,
+//!   4. on any failure, capture a post-mortem from the still-alive VM
+//!      and surface it as structured `diagnostics` so the upstream
+//!      `AgentEvent.metadata` carries the root-cause hints to
+//!      cirun-go.
+//!
+//! Centralising the lifecycle here means: (a) the OpenSSH-channel
+//! kill-after-PID fix lives in one place, (b) observability metadata
+//! is identical across executors, (c) adding a new SSH-based backend
+//! is a 10-line adapter, not a 200-line copy.
+
+use std::time::Duration;
+
+use crate::ssh::{copy_file, exec_detached_get_pid, test_connection, SshTarget};
+
+/// All the per-attempt context the shared lifecycle needs. Filled in
+/// by the executor adapter (meda/lume) before each call. Kept as
+/// plain fields rather than a builder — every executor sets all of
+/// them, the call site reads the struct top-to-bottom, and there's
+/// nothing optional that benefits from a fluent API.
+pub struct PushContext<'a> {
+    pub vm_name: &'a str,
+    pub vm_ip: &'a str,
+    /// Pre-built SSH target (key auth for meda, password for lume).
+    pub target: SshTarget,
+    /// Provision-script body to upload + run.
+    pub script: &'a str,
+    /// Whether to invoke the remote script under `sudo`. meda needs
+    /// it (the cirun user can't write outside its home); lume's
+    /// macOS template user is already an admin, so it runs without.
+    pub use_sudo: bool,
+    /// Hard cap for the detached-exec call. Independent of the
+    /// nohup'd script's own runtime — once the PID is read, SSH gets
+    /// killed and this timeout no longer applies.
+    pub detached_exec_timeout: Duration,
+}
+
+/// Failure from `push_and_run_detached`. The `diagnostics` map is
+/// built to be folded straight into `AgentEvent.metadata`, so every
+/// key here is one cirun-go ends up logging structured-and-greppable
+/// in Loki.
+///
+/// `diagnostics` is currently only consumed by meda (which threads
+/// it into `ProvisionError::transient_with`); lume drops it because
+/// its legacy error chain doesn't carry structured metadata yet.
+/// The `allow(dead_code)` keeps `-D warnings` happy on the macOS
+/// build without forcing a parallel lume-side refactor.
+pub struct PushFailure {
+    pub message: String,
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub diagnostics: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Run the shared post-spawn lifecycle against the VM in `ctx`.
+/// Returns the remote PID on success; on failure, returns a
+/// structured error carrying SSH timing + a VM-side state snapshot.
+///
+/// Steps (in order):
+///   1. retry SSH connectivity up to `SSH_RETRY_COUNT` times
+///   2. SCP the script to a `/tmp/script_*.sh` path
+///   3. fire the detached-exec command (`script_cmd::detached_provision_cmd`)
+///   4. on detached-exec failure, run `script_cmd::diagnostic_capture_cmd`
+///      against the still-alive VM and stuff the output into the
+///      diagnostics bag before returning
+pub async fn push_and_run_detached(ctx: &PushContext<'_>) -> Result<u32, PushFailure> {
+    use std::io::Write;
+    use std::time::Instant;
+
+    log::info!("VM '{}' is ready with IP: {}", ctx.vm_name, ctx.vm_ip);
+
+    // 1. Stage the script locally so scp can transfer it. NamedTempFile
+    //    auto-deletes on drop; we hold it through the SCP call.
+    let mut tmp = match tempfile::NamedTempFile::new() {
+        Ok(f) => f,
+        Err(e) => return Err(simple_failure(format!("tempfile: {e}"), ctx)),
+    };
+    if let Err(e) = tmp.write_all(ctx.script.as_bytes()) {
+        return Err(simple_failure(format!("write tempfile: {e}"), ctx));
+    }
+
+    // 2. Wait for SSH to be ready. The VM's IP DHCP-leased before
+    //    sshd was listening, so a few short retries are normal.
+    if let Err(msg) = wait_for_ssh(&ctx.target).await {
+        return Err(simple_failure(format!("SSH not reachable: {msg}"), ctx));
+    }
+
+    // 3. SCP the script onto the VM at a unique path.
+    let remote_path = format!("/tmp/script_{}.sh", Instant::now().elapsed().as_secs());
+    if let Err(e) = copy_file(&ctx.target, tmp.path(), &remote_path).await {
+        return Err(simple_failure(format!("scp: {e}"), ctx));
+    }
+
+    // 4. Fire the detached-exec call. `exec_detached_get_pid` kills
+    //    SSH the moment it sees the PID line — no waiting for
+    //    channel close, no 60s-timer roulette.
+    let cmd = crate::script_cmd::detached_provision_cmd(&remote_path, ctx.use_sudo);
+    log::info!(
+        "exec start: vm={} ip={} detached=true timeout={}s",
+        ctx.vm_name,
+        ctx.vm_ip,
+        ctx.detached_exec_timeout.as_secs()
+    );
+
+    match exec_detached_get_pid(&ctx.target, &cmd, ctx.detached_exec_timeout).await {
+        Ok(ok) => {
+            log::info!(
+                "exec ok: vm={} pid={} elapsed_ms={}",
+                ctx.vm_name,
+                ok.pid,
+                ok.elapsed_ms
+            );
+            Ok(ok.pid)
+        }
+        Err(e) => {
+            // The VM is still alive at this point. Grab a post-mortem
+            // via a separate SSH connection BEFORE the upstream
+            // lifecycle deletes the box. Both the Loki log line and
+            // the structured bag carry the same payload so we get
+            // observability whether or not the agent-event POST
+            // succeeds.
+            let vm_diag = capture_diagnostics(&ctx.target).await;
+            log::warn!(
+                "exec failed: vm={} ip={} elapsed_ms={} ssh_error={} \n--- diagnostics ---\n{}",
+                ctx.vm_name,
+                ctx.vm_ip,
+                e.elapsed_ms,
+                e.message,
+                vm_diag
+            );
+
+            let mut diagnostics = base_diagnostics(ctx);
+            diagnostics.insert(
+                "exec_elapsed_ms".into(),
+                serde_json::Value::from(e.elapsed_ms as u64),
+            );
+            diagnostics.insert(
+                "exec_timeout_secs".into(),
+                serde_json::Value::from(ctx.detached_exec_timeout.as_secs()),
+            );
+            diagnostics.insert(
+                "ssh_error".into(),
+                serde_json::Value::from(e.message.clone()),
+            );
+            if !e.partial_stdout.is_empty() {
+                diagnostics.insert(
+                    "partial_stdout".into(),
+                    serde_json::Value::from(e.partial_stdout),
+                );
+            }
+            if !e.partial_stderr.is_empty() {
+                diagnostics.insert(
+                    "partial_stderr".into(),
+                    serde_json::Value::from(e.partial_stderr),
+                );
+            }
+            diagnostics.insert("vm_diagnostics".into(), serde_json::Value::from(vm_diag));
+            Err(PushFailure {
+                message: e.message,
+                diagnostics,
+            })
+        }
+    }
+}
+
+/// Build the baseline diagnostics map every failure path emits —
+/// keeps the per-error code below from re-stating runner identity.
+fn base_diagnostics(ctx: &PushContext<'_>) -> serde_json::Map<String, serde_json::Value> {
+    let mut m = serde_json::Map::new();
+    m.insert(
+        "vm_name".into(),
+        serde_json::Value::from(ctx.vm_name.to_string()),
+    );
+    m.insert(
+        "vm_ip".into(),
+        serde_json::Value::from(ctx.vm_ip.to_string()),
+    );
+    m.insert("use_sudo".into(), serde_json::Value::from(ctx.use_sudo));
+    m
+}
+
+/// Shape for the "we never reached detached-exec" failure paths
+/// (tempfile, SSH-retry, scp). They share the baseline runner-shape
+/// metadata so the cirun-go event log entry looks identical to a
+/// detached-exec failure modulo the missing `exec_*` keys.
+fn simple_failure(message: String, ctx: &PushContext<'_>) -> PushFailure {
+    let mut diagnostics = base_diagnostics(ctx);
+    diagnostics.insert("phase".into(), serde_json::Value::from("pre_detached_exec"));
+    PushFailure {
+        message,
+        diagnostics,
+    }
+}
+
+/// SSH-readiness probe loop. Six tries with a 5s sleep between
+/// attempts (~30s budget). Returns the last error string if every
+/// attempt failed.
+async fn wait_for_ssh(target: &SshTarget) -> Result<(), String> {
+    const MAX_RETRIES: usize = 6;
+    let mut last_err: Option<String> = None;
+    for attempt in 1..=MAX_RETRIES {
+        match test_connection(target).await {
+            Ok(()) => {
+                log::info!("✔ SSH ready (attempt {}/{})", attempt, MAX_RETRIES);
+                return Ok(());
+            }
+            Err(e) => {
+                last_err = Some(e.to_string());
+                if attempt < MAX_RETRIES {
+                    log::info!("SSH not ready (attempt {}/{}): {}", attempt, MAX_RETRIES, e);
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| "no attempts made".into()))
+}
+
+/// Best-effort post-mortem of a VM that just failed a detached exec.
+/// Runs the read-only `script_cmd::diagnostic_capture_cmd` probe via
+/// a separate SSH connection with its own short timeout. On any
+/// failure (probe times out, ssh drops, …) returns a marker string
+/// so the caller can still emit a coherent log line.
+async fn capture_diagnostics(target: &SshTarget) -> String {
+    let probe = crate::script_cmd::diagnostic_capture_cmd();
+    match crate::ssh::exec(target, probe, Duration::from_secs(15)).await {
+        Ok(out) => out,
+        Err(e) => format!("(diagnostic capture failed: {e})"),
+    }
+}

--- a/src/reporting.rs
+++ b/src/reporting.rs
@@ -37,7 +37,14 @@ pub enum ProvisionEvent {
     Succeeded { runner_name: String },
 
     /// Real provisioning failure (executor error, bad spec, network).
-    Failed { runner_name: String, error: String },
+    /// `diagnostics` is an open-ended structured bag that gets merged
+    /// into the upstream `AgentEvent.metadata` — meda's detached-exec
+    /// failure path uses it to attach SSH timing and VM-side state.
+    Failed {
+        runner_name: String,
+        error: String,
+        diagnostics: serde_json::Map<String, serde_json::Value>,
+    },
 
     /// Host admission control rejected the request (meda 503). Runner
     /// was never spawned; retry budget MUST be preserved.
@@ -62,9 +69,10 @@ impl From<ProvisionResult> for ProvisionEvent {
             ProvisionOutcome::Success => ProvisionEvent::Succeeded {
                 runner_name: pr.runner_name,
             },
-            ProvisionOutcome::Failed(error) => ProvisionEvent::Failed {
+            ProvisionOutcome::Failed { error, diagnostics } => ProvisionEvent::Failed {
                 runner_name: pr.runner_name,
                 error,
+                diagnostics,
             },
             ProvisionOutcome::HostFull {
                 code,
@@ -146,8 +154,17 @@ pub enum Severity {
 pub fn to_agent_event(ev: &ProvisionEvent, attempt: u32) -> Option<AgentEvent> {
     match ev {
         ProvisionEvent::Succeeded { .. } => None,
-        ProvisionEvent::Failed { runner_name, error } => {
-            let mut metadata = serde_json::Map::new();
+        ProvisionEvent::Failed {
+            runner_name,
+            error,
+            diagnostics,
+        } => {
+            // Start from the caller-provided diagnostics so the AgentEvent
+            // carries the structured root-cause hints (SSH timing,
+            // VM-side state). Then layer the canonical `attempt`/`error`
+            // keys on top — those two are guaranteed to be present so
+            // cirun-go's dispatch can rely on them.
+            let mut metadata = diagnostics.clone();
             metadata.insert("attempt".into(), serde_json::Value::from(attempt));
             metadata.insert("error".into(), serde_json::Value::from(error.clone()));
             Some(AgentEvent {
@@ -231,7 +248,7 @@ mod tests {
         ProvisionResult {
             runner_name: name.into(),
             executor_kind: None,
-            outcome: ProvisionOutcome::Failed(err.into()),
+            outcome: ProvisionOutcome::failed(err),
         }
     }
     fn pr_host_full(name: &str, code: &str) -> ProvisionResult {
@@ -280,6 +297,7 @@ mod tests {
         let ev = ProvisionEvent::Failed {
             runner_name: "r1".into(),
             error: "boom".into(),
+            diagnostics: serde_json::Map::new(),
         };
         let agent_event = to_agent_event(&ev, 3).expect("should emit");
         assert_eq!(agent_event.kind, EventKind::ProvisionFailed);
@@ -292,6 +310,66 @@ mod tests {
         assert_eq!(
             agent_event.metadata.get("error"),
             Some(&serde_json::Value::from("boom"))
+        );
+    }
+
+    #[test]
+    fn failed_event_carries_caller_supplied_diagnostics_into_metadata() {
+        // The whole point of the diagnostics field is that meda's
+        // detached-exec failure path can attach SSH timing + VM-side
+        // state; if that doesn't survive into the wire-format metadata
+        // we've lost the observability we built it for.
+        let mut diag = serde_json::Map::new();
+        diag.insert("elapsed_ms".into(), serde_json::Value::from(37386));
+        diag.insert("partial_stdout".into(), serde_json::Value::from("18066\n"));
+        diag.insert(
+            "vm_diagnostics".into(),
+            serde_json::Value::from("=== ps ===\n..."),
+        );
+        let ev = ProvisionEvent::Failed {
+            runner_name: "r1".into(),
+            error: "ssh exec timed out".into(),
+            diagnostics: diag,
+        };
+        let agent_event = to_agent_event(&ev, 1).expect("should emit");
+        assert_eq!(
+            agent_event.metadata.get("elapsed_ms"),
+            Some(&serde_json::Value::from(37386))
+        );
+        assert_eq!(
+            agent_event.metadata.get("partial_stdout"),
+            Some(&serde_json::Value::from("18066\n"))
+        );
+        assert!(agent_event
+            .metadata
+            .get("vm_diagnostics")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .contains("=== ps ==="));
+    }
+
+    #[test]
+    fn canonical_metadata_keys_override_caller_diagnostics() {
+        // cirun-go relies on `attempt` and `error` being canonical
+        // keys; if a caller stuffed conflicting values into the
+        // diagnostics bag, the canonical ones must still win so
+        // dispatch behaviour stays predictable.
+        let mut diag = serde_json::Map::new();
+        diag.insert("attempt".into(), serde_json::Value::from(99));
+        diag.insert("error".into(), serde_json::Value::from("wrong"));
+        let ev = ProvisionEvent::Failed {
+            runner_name: "r1".into(),
+            error: "real error".into(),
+            diagnostics: diag,
+        };
+        let agent_event = to_agent_event(&ev, 2).expect("should emit");
+        assert_eq!(
+            agent_event.metadata.get("attempt"),
+            Some(&serde_json::Value::from(2))
+        );
+        assert_eq!(
+            agent_event.metadata.get("error"),
+            Some(&serde_json::Value::from("real error"))
         );
     }
 

--- a/src/script_cmd.rs
+++ b/src/script_cmd.rs
@@ -21,6 +21,28 @@ pub fn detached_provision_cmd(remote_path: &str, use_sudo: bool) -> String {
     )
 }
 
+/// Build a single-shot diagnostic command that captures the state of a
+/// VM mid-provision: process list, the tail of the script's stdout/stderr
+/// captures, the cirun provision log, and the fd table of every bash
+/// process (so we can see what's still holding open the SSH channel).
+///
+/// Section headers (`=== name ===`) bracket each block so a Loki search
+/// for the failing runner name returns the full payload as one
+/// contiguous message. All commands tolerate missing files / lack of
+/// permission so the capture never aborts mid-bundle.
+// Linux-only consumer (`executor::meda`); macOS lume path doesn't use it yet.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn diagnostic_capture_cmd() -> &'static str {
+    "echo '=== uptime ==='; uptime; \
+     echo '=== ps ==='; ps -eo pid,ppid,stat,etime,cmd 2>/dev/null | head -50; \
+     echo '=== /tmp/script_stdout.log (tail 50) ==='; sudo tail -50 /tmp/script_stdout.log 2>/dev/null; \
+     echo '=== /tmp/script_stderr.log (tail 50) ==='; sudo tail -50 /tmp/script_stderr.log 2>/dev/null; \
+     echo '=== /tmp/cirun-provision.log (tail 50) ==='; sudo tail -50 /tmp/cirun-provision.log 2>/dev/null; \
+     echo '=== bash fd table ==='; for p in $(pgrep bash 2>/dev/null); do echo \"--- pid=$p ---\"; sudo ls -la /proc/$p/fd 2>/dev/null | head -10; done; \
+     echo '=== runner-listener? ==='; pgrep -af Runner.Listener 2>/dev/null; \
+     echo '=== END ==='"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +86,39 @@ mod tests {
         let cmd = detached_provision_cmd("/tmp/script_0.sh", false);
         assert!(cmd.contains("nohup /tmp/script_0.sh"));
         assert!(!cmd.contains("sudo"));
+    }
+
+    #[test]
+    fn diagnostic_capture_includes_required_sections() {
+        let cmd = diagnostic_capture_cmd();
+        for marker in [
+            "=== uptime ===",
+            "=== ps ===",
+            "=== /tmp/script_stdout.log",
+            "=== /tmp/script_stderr.log",
+            "=== /tmp/cirun-provision.log",
+            "=== bash fd table ===",
+            "=== runner-listener? ===",
+            "=== END ===",
+        ] {
+            assert!(
+                cmd.contains(marker),
+                "diagnostic capture missing section {marker:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn diagnostic_capture_tolerates_missing_files() {
+        // Every tail/ls/pgrep must swallow non-zero exits so the whole
+        // capture doesn't bail when a file isn't present yet.
+        let cmd = diagnostic_capture_cmd();
+        let tail_count = cmd.matches("tail -50").count();
+        let suppression_count = cmd.matches("2>/dev/null").count();
+        assert!(
+            suppression_count >= tail_count,
+            "every tail must redirect stderr; got tail_count={tail_count} \
+             suppression_count={suppression_count}"
+        );
     }
 }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -179,18 +179,292 @@ impl SshTarget {
 }
 
 /// Run a remote command via SSH with a hard timeout. Captures stdout/stderr.
+///
+/// On timeout, the partial stdout/stderr buffered up to the kill point is
+/// included in the error message — this is the only way to tell whether the
+/// remote command silently hung mid-output vs. SSH itself was the one
+/// holding the channel open after `echo` already printed its result.
 pub async fn exec(target: &SshTarget, remote_cmd: &str, timeout: Duration) -> Result<String> {
-    let output = tokio::time::timeout(timeout, target.ssh_cmd(remote_cmd).output())
-        .await
-        .map_err(|_| anyhow!("SSH exec timed out after {:?}", timeout))?
+    use std::sync::{Arc, Mutex};
+    use tokio::io::AsyncReadExt;
+
+    let start = std::time::Instant::now();
+    let mut child = target
+        .ssh_cmd(remote_cmd)
+        .spawn()
         .map_err(|e| anyhow!("SSH spawn error: {}", e))?;
-    if !output.status.success() {
-        return Err(anyhow!(
-            "SSH exec failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("no stdout pipe"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("no stderr pipe"))?;
+
+    let out_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let err_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let out_writer = Arc::clone(&out_buf);
+    let err_writer = Arc::clone(&err_buf);
+    let out_task = tokio::spawn(async move {
+        let mut s = stdout;
+        let mut local = Vec::new();
+        let _ = s.read_to_end(&mut local).await;
+        out_writer.lock().unwrap().extend(local);
+    });
+    let err_task = tokio::spawn(async move {
+        let mut s = stderr;
+        let mut local = Vec::new();
+        let _ = s.read_to_end(&mut local).await;
+        err_writer.lock().unwrap().extend(local);
+    });
+
+    let snapshot = |label: &str, buf: &Arc<Mutex<Vec<u8>>>| {
+        let bytes = buf.lock().unwrap().clone();
+        format!("{label}={:?}", String::from_utf8_lossy(&bytes))
+    };
+
+    match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => {
+            // Drain readers (briefly) so we get the full stdio.
+            let _ = tokio::time::timeout(Duration::from_secs(1), async {
+                let _ = out_task.await;
+                let _ = err_task.await;
+            })
+            .await;
+            let out = String::from_utf8_lossy(&out_buf.lock().unwrap()).to_string();
+            if !status.success() {
+                let err = String::from_utf8_lossy(&err_buf.lock().unwrap()).to_string();
+                return Err(anyhow!(
+                    "SSH exec failed (status={}, elapsed={}ms): stderr={}",
+                    status,
+                    start.elapsed().as_millis(),
+                    err
+                ));
+            }
+            Ok(out)
+        }
+        Ok(Err(e)) => Err(anyhow!("SSH wait error: {}", e)),
+        Err(_) => {
+            // Hard cap reached. Kill ssh; preserve whatever it had buffered.
+            let _ = child.kill().await;
+            let _ = tokio::time::timeout(Duration::from_millis(500), async {
+                let _ = out_task.await;
+                let _ = err_task.await;
+            })
+            .await;
+            Err(anyhow!(
+                "SSH exec timed out after {:?} (elapsed={}ms); partial {}; partial {}",
+                timeout,
+                start.elapsed().as_millis(),
+                snapshot("stdout", &out_buf),
+                snapshot("stderr", &err_buf),
+            ))
+        }
     }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Result of a successful detached-exec: the PID the remote command
+/// echoed plus the timing/stdio captured up to the kill point. The
+/// `stdout` and `stderr` fields are surfaced for callers that want
+/// to log the surrounding ssh chatter (e.g. known-hosts warnings)
+/// but no current caller consumes them.
+#[derive(Debug, Clone)]
+pub struct DetachedOk {
+    pub pid: u32,
+    pub elapsed_ms: u128,
+    #[allow(dead_code)]
+    pub stdout: String,
+    #[allow(dead_code)]
+    pub stderr: String,
+}
+
+/// Result of a failed detached-exec: structured enough that callers
+/// can stuff the fields straight into a metadata bag without further
+/// parsing.
+#[derive(Debug, Clone)]
+pub struct DetachedErr {
+    pub message: String,
+    pub elapsed_ms: u128,
+    pub partial_stdout: String,
+    pub partial_stderr: String,
+}
+
+impl std::fmt::Display for DetachedErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+/// Parse a stdout line as a PID. Accepts an optional trailing newline
+/// and leading/trailing whitespace; rejects anything non-numeric or
+/// empty. Extracted from `exec_detached_get_pid` so the parse rules
+/// are testable without spawning a child process.
+fn parse_pid_line(line: &str) -> Option<u32> {
+    line.trim().parse::<u32>().ok()
+}
+
+/// Run a remote command via SSH and return as soon as the remote
+/// printed a PID-shaped line. Unlike `exec`, this does NOT wait for
+/// the SSH channel to close — once we have the PID we kill the SSH
+/// client immediately.
+///
+/// The detached-mode provision flow needs this because the remote
+/// command's structure is `nohup background-script & echo $!`: the
+/// PID prints in ~milliseconds but OpenSSH keeps the channel open for
+/// tens of seconds waiting for the backgrounded fds to release. With
+/// `exec`'s "wait for child exit" semantics, every provision was
+/// gambling against the 60s timeout cliff; this primitive removes
+/// the gamble entirely.
+pub async fn exec_detached_get_pid(
+    target: &SshTarget,
+    remote_cmd: &str,
+    timeout: Duration,
+) -> std::result::Result<DetachedOk, DetachedErr> {
+    use std::sync::{Arc, Mutex};
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::sync::oneshot;
+
+    let start = std::time::Instant::now();
+
+    let mut child = match target.ssh_cmd(remote_cmd).spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(DetachedErr {
+                message: format!("SSH spawn error: {e}"),
+                elapsed_ms: start.elapsed().as_millis(),
+                partial_stdout: String::new(),
+                partial_stderr: String::new(),
+            });
+        }
+    };
+
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => {
+            return Err(DetachedErr {
+                message: "no stdout pipe".into(),
+                elapsed_ms: start.elapsed().as_millis(),
+                partial_stdout: String::new(),
+                partial_stderr: String::new(),
+            });
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(s) => s,
+        None => {
+            return Err(DetachedErr {
+                message: "no stderr pipe".into(),
+                elapsed_ms: start.elapsed().as_millis(),
+                partial_stdout: String::new(),
+                partial_stderr: String::new(),
+            });
+        }
+    };
+
+    // Buffer stderr in the background so we can include it in any
+    // error path without blocking on EOF.
+    let err_buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let err_writer = Arc::clone(&err_buf);
+    let err_task = tokio::spawn(async move {
+        use tokio::io::AsyncReadExt;
+        let mut s = stderr;
+        let mut local = Vec::new();
+        let _ = s.read_to_end(&mut local).await;
+        err_writer.lock().unwrap().extend(local);
+    });
+
+    // Stream stdout line-by-line. As soon as we hit a parseable PID
+    // line we resolve and break out of the loop — the read task gets
+    // dropped, which closes our end of the pipe.
+    let (tx, rx) = oneshot::channel::<std::result::Result<(u32, String), String>>();
+    let stdout_task = tokio::spawn(async move {
+        let mut reader = BufReader::new(stdout);
+        let mut accumulated = String::new();
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => {
+                    let _ = tx.send(Err(format!("EOF before PID line; got: {accumulated:?}")));
+                    return;
+                }
+                Ok(_) => {
+                    accumulated.push_str(&line);
+                    if let Some(pid) = parse_pid_line(&line) {
+                        let _ = tx.send(Ok((pid, accumulated.clone())));
+                        return;
+                    }
+                    // Non-PID line (warnings like "Permanently added
+                    // ..." from known-hosts). Keep reading.
+                }
+                Err(e) => {
+                    let _ = tx.send(Err(format!("stdout read error: {e}")));
+                    return;
+                }
+            }
+        }
+    });
+
+    let outcome = tokio::time::timeout(timeout, rx).await;
+    let stderr_snapshot = || String::from_utf8_lossy(&err_buf.lock().unwrap()).to_string();
+
+    // Whether we resolved or timed out: we have the PID we need (or
+    // we've given up); kill the SSH client to release the channel.
+    // The remote nohup'd process is independent of this client.
+    match outcome {
+        Ok(Ok(Ok((pid, accumulated)))) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            stdout_task.abort();
+            let _ = err_task.await;
+            Ok(DetachedOk {
+                pid,
+                elapsed_ms: start.elapsed().as_millis(),
+                stdout: accumulated,
+                stderr: stderr_snapshot(),
+            })
+        }
+        Ok(Ok(Err(msg))) => {
+            let _ = child.kill().await;
+            stdout_task.abort();
+            let _ = err_task.await;
+            Err(DetachedErr {
+                message: msg,
+                elapsed_ms: start.elapsed().as_millis(),
+                partial_stdout: String::new(),
+                partial_stderr: stderr_snapshot(),
+            })
+        }
+        Ok(Err(_)) => {
+            // Sender dropped — only happens if the stdout task itself
+            // panicked, which would mean the BufReader couldn't be
+            // constructed (impossible — we already pulled the pipe).
+            // Surface defensively as a generic failure.
+            let _ = child.kill().await;
+            stdout_task.abort();
+            let _ = err_task.await;
+            Err(DetachedErr {
+                message: "stdout reader task ended unexpectedly".into(),
+                elapsed_ms: start.elapsed().as_millis(),
+                partial_stdout: String::new(),
+                partial_stderr: stderr_snapshot(),
+            })
+        }
+        Err(_) => {
+            let _ = child.kill().await;
+            stdout_task.abort();
+            let _ = err_task.await;
+            Err(DetachedErr {
+                message: format!("detached exec timed out after {timeout:?}"),
+                elapsed_ms: start.elapsed().as_millis(),
+                partial_stdout: String::new(),
+                partial_stderr: stderr_snapshot(),
+            })
+        }
+    }
 }
 
 /// Cheap connectivity probe: runs `echo` over SSH. Returns Ok if the connection works.
@@ -226,6 +500,49 @@ pub async fn copy_file(target: &SshTarget, local: &Path, remote: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_pid_line_accepts_plain_digits() {
+        assert_eq!(parse_pid_line("18066"), Some(18066));
+    }
+
+    #[test]
+    fn parse_pid_line_trims_trailing_newline() {
+        assert_eq!(parse_pid_line("18066\n"), Some(18066));
+    }
+
+    #[test]
+    fn parse_pid_line_trims_surrounding_whitespace() {
+        assert_eq!(parse_pid_line("  18066  \r\n"), Some(18066));
+    }
+
+    #[test]
+    fn parse_pid_line_rejects_non_digits() {
+        // OpenSSH chatter ("Permanently added '…' (ED25519) to the
+        // list of known hosts.") would land in stdout if the agent
+        // ever forgot `UserKnownHostsFile=/dev/null`; we must NOT
+        // treat that line as a PID — otherwise the agent reports
+        // success on a busted provision.
+        for s in [
+            "Permanently added '10.0.0.1' (ED25519)",
+            "",
+            "    ",
+            "12abc",
+            "abc",
+            "12.3",
+        ] {
+            assert!(
+                parse_pid_line(s).is_none(),
+                "parse_pid_line wrongly accepted: {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_pid_line_rejects_overflow() {
+        // u32::MAX + 1 — must fail rather than wrap.
+        assert!(parse_pid_line("4294967296").is_none());
+    }
 
     #[test]
     fn safe_identifier_accepts_normal_usernames_and_hosts() {

--- a/src/vm_provision.rs
+++ b/src/vm_provision.rs
@@ -56,11 +56,7 @@ pub async fn run_script_on_vm(
 
     use crate::ssh::{copy_file, exec, test_connection, SshAuth, SshTarget};
 
-    info!("Creating temporary script file");
-    let mut temp_file = NamedTempFile::new()?;
-    temp_file.write_all(script_content.as_bytes())?;
-
-    // password_tmp must outlive the target (dropped on function exit auto-deletes).
+    // password_tmp must outlive the SshTarget (dropped on function exit auto-deletes).
     let password_tmp = create_password_file(password)?;
     info!(
         "SSH target: {}@{} (password auth, password length={})",
@@ -73,6 +69,32 @@ pub async fn run_script_on_vm(
         username.to_string(),
         SshAuth::PasswordFile(password_tmp.path().to_path_buf()),
     )?;
+
+    // Detached path is shared with meda via `provision_push` so both
+    // SSH-based executors get the same kill-after-PID-read fix and
+    // the same structured-diagnostics observability bag. The blocking
+    // path (run_detached=false) stays inline — it owns the 10-minute
+    // "wait for the script to complete" lifetime which the shared
+    // module deliberately does not handle.
+    if run_detached {
+        let ctx = crate::provision_push::PushContext {
+            vm_name,
+            vm_ip: &ip_address,
+            target,
+            script: script_content,
+            use_sudo: false, // lume's macOS template user is already admin
+            detached_exec_timeout: Duration::from_secs(60),
+        };
+        let pid = crate::provision_push::push_and_run_detached(&ctx)
+            .await
+            .map_err(|f| -> Box<dyn std::error::Error> { f.message.into() })?;
+        drop(password_tmp);
+        return Ok(format!("{pid}\n"));
+    }
+
+    info!("Creating temporary script file");
+    let mut temp_file = NamedTempFile::new()?;
+    temp_file.write_all(script_content.as_bytes())?;
 
     // Test SSH (VM may still be booting). Use backon for exponential retry.
     (|| async { test_connection(&target).await })
@@ -96,22 +118,14 @@ pub async fn run_script_on_vm(
     .notify(|err, dur| warn!("Retrying SCP transfer after {:?}: {:?}", dur, err))
     .await?;
 
-    // Execute. Detached: short launch timeout. Blocking: 10min.
-    let (timeout_secs, cmd) = if run_detached {
-        (
-            60u64,
-            crate::script_cmd::detached_provision_cmd(&remote_script_path, false),
-        )
-    } else {
-        (
-            600u64,
-            format!("chmod +x {p} && {p}", p = remote_script_path),
-        )
-    };
+    // Blocking path: run the script foreground, wait up to 10 minutes
+    // for it to finish, return its stdout. Used by lume template
+    // creation today, not by per-runner provision.
+    let cmd = format!("chmod +x {p} && {p}", p = remote_script_path);
     let script_output = (|| {
         let target = &target;
         let cmd = cmd.clone();
-        async move { exec(target, &cmd, tokio::time::Duration::from_secs(timeout_secs)).await }
+        async move { exec(target, &cmd, tokio::time::Duration::from_secs(600)).await }
     })
     .retry(ExponentialBuilder::default().with_max_times(3))
     .sleep(tokio::time::sleep)


### PR DESCRIPTION
## Summary
- Detached-mode provisioning previously waited for OpenSSH to close the channel after `nohup … & echo $!` printed the PID. The wait took 30–60 s; the 60 s hard timeout on `exec` fired regularly, and the caller responded by deleting a VM that already had a healthy runner registered. Fixed by spawning SSH manually, reading the PID line, and `SIGKILL`-ing the client immediately.
- Shared `provision_push` module now owns the post-spawn lifecycle for every SSH-based executor (meda + lume): retry SSH → scp → detached-exec via `exec_detached_get_pid` → on failure, run `script_cmd::diagnostic_capture_cmd` against the still-alive VM and pack the snapshot into a structured bag.
- The bag rides up through `ProvisionError::Transient { diagnostics }` → `ProvisionOutcome::Failed { diagnostics }` → `ProvisionEvent::Failed { diagnostics }` and gets merged into `AgentEvent.metadata` POSTed to `/api/v1/agent`. Canonical `attempt` / `error` keys still win on conflict.

## Verification
- meda dev host: detached-exec `elapsed_ms` dropped from 48 000–60 000 → **247–284 ms**.
- m1 lume host (same shared module): **342–556 ms**.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all clean (100 tests, +5 vs main).